### PR TITLE
Refactor VBA import/export module and add import helpers

### DIFF
--- a/Dev_ImportExportVBAModules.bas
+++ b/Dev_ImportExportVBAModules.bas
@@ -1,4 +1,4 @@
-Attribute VB_Name = "Dev_ExportVBAModules"
+Attribute VB_Name = "Dev_ImportExportVBAModules"
 Option Explicit
 
 '===========================================================
@@ -6,13 +6,15 @@ Option Explicit
 '   Export all VBA modules (Std/Class/UserForms) to a user-
 '   selected folder using a Save As dialog (robust when the
 '   workbook path is an Office/OneDrive URL such as
-'   https://d.docs.live.net/...).
+'   https://d.docs.live.net/...), plus import standard modules
+'   from .bas files in a selected folder.
 '
 ' Inputs:
 '   - ThisWorkbook.VBProject.VBComponents
 '
 ' Outputs / Side effects:
 '   - Exports .bas / .cls / .frm (+ .frx)
+'   - Imports .bas (standard modules only)
 '   - Creates _EXPORT_INFO.txt in the destination folder
 '
 ' Preconditions:
@@ -25,10 +27,19 @@ Option Explicit
 '   - Continues on per-component export failures
 '   - Reports failures in Immediate Window (Ctrl+G)
 '
-' Version: v1.0.0
+' Version: v1.1.0
 ' Author:  ChatGPT (CUSTOM Tracker)
 ' Date:    2025-12-19
 '===========================================================
+
+Private Const VB_COMP_STD_MODULE As Long = 1
+Private Const VB_COMP_CLASS_MODULE As Long = 2
+Private Const VB_COMP_USERFORM As Long = 3
+Private Const DIALOG_FOLDER_PICKER As Long = 4
+
+'========================
+' Public entry points
+'========================
 
 Public Sub Export_All_VBAModules_SaveAsFolder()
     Const PROC_NAME As String = "Export_All_VBAModules_SaveAsFolder"
@@ -71,9 +82,7 @@ Public Sub Export_All_VBAModules_SaveAsFolder()
         Exit Sub
     End If
 
-    Debug.Print "=== " & PROC_NAME & " ==="
-    Debug.Print "Workbook: " & ThisWorkbook.Name
-    Debug.Print "ExportFolder: " & exportFolder
+    LogHeader PROC_NAME, exportFolder
 
     okCount = 0: failCount = 0: hadErr52 = False: failReport = vbNullString
     ExportComponentsToFolder exportFolder, okCount, failCount, hadErr52, failReport
@@ -98,6 +107,89 @@ EH:
         "Error in " & PROC_NAME & vbCrLf & _
         "Err " & Err.Number & ": " & Err.Description, _
         vbCritical, "Export Failed"
+End Sub
+
+Public Sub Import_All_BAS_Modules_FromFolder()
+    Const PROC_NAME As String = "Import_All_BAS_Modules_FromFolder"
+
+    Dim importFolder As String
+    Dim fileName As String
+    Dim filePath As String
+    Dim moduleName As String
+    Dim vbComp As Object
+    Dim okCount As Long, failCount As Long
+    Dim foundCount As Long
+
+    On Error GoTo EH
+
+    If Not CanAccessVBAProject() Then
+        MsgBox _
+            "VBA import blocked." & vbCrLf & _
+            "Enable: File ? Options ? Trust Center ? Trust Center Settings ?" & vbCrLf & _
+            "Macro Settings ? 'Trust access to the VBA project model'.", _
+            vbCritical, "Import Failed"
+        Exit Sub
+    End If
+
+    importFolder = PickImportFolder()
+    If Len(importFolder) = 0 Then Exit Sub
+
+    LogHeader PROC_NAME, importFolder
+
+    okCount = 0: failCount = 0: foundCount = 0
+
+    fileName = Dir(importFolder & "\*.bas")
+    Do While Len(fileName) > 0
+        foundCount = foundCount + 1
+        filePath = importFolder & "\" & fileName
+        moduleName = Left$(fileName, Len(fileName) - 4)
+
+        On Error GoTo ImportFail
+
+        RemoveStandardModuleIfExists moduleName, vbComp
+
+        ThisWorkbook.VBProject.VBComponents.Import filePath
+        Debug.Print "OK: " & moduleName & " <- " & filePath
+        okCount = okCount + 1
+        On Error GoTo 0
+
+ContinueNext:
+        fileName = Dir()
+    Loop
+
+    If foundCount = 0 Then
+        MsgBox _
+            "No .bas files found in the selected folder." & vbCrLf & _
+            "Folder: " & importFolder, _
+            vbInformation, "Import Results"
+        Exit Sub
+    End If
+
+    MsgBox _
+        "VBA import complete." & vbCrLf & _
+        "Folder: " & importFolder & vbCrLf & _
+        "OK: " & okCount & "   Failed: " & failCount & _
+        IIf(failCount > 0, vbCrLf & vbCrLf & "See Immediate Window (Ctrl+G) for details.", ""), _
+        IIf(failCount > 0, vbExclamation, vbInformation), _
+        "Import Results"
+
+    Exit Sub
+
+ImportFail:
+    failCount = failCount + 1
+
+    Debug.Print "FAIL: " & moduleName & " -> " & filePath
+    Debug.Print "      Err " & Err.Number & ": " & Err.Description
+
+    Err.Clear
+    On Error GoTo 0
+    GoTo ContinueNext
+
+EH:
+    MsgBox _
+        "Error in " & PROC_NAME & vbCrLf & _
+        "Err " & Err.Number & ": " & Err.Description, _
+        vbCritical, "Import Failed"
 End Sub
 
 '========================
@@ -168,6 +260,7 @@ Private Sub WriteExportInfo(ByVal exportFolder As String, ByVal okCount As Long,
     ts.WriteLine "OK: " & okCount
     ts.WriteLine "Failed: " & failCount
     ts.WriteLine "HadErr52: " & IIf(hadErr52, "YES", "NO")
+    ts.WriteLine "Import: Run Import_All_BAS_Modules_FromFolder to import .bas modules from this folder."
     ts.Close
 End Sub
 
@@ -191,6 +284,21 @@ Private Function GetDefaultExportStub() As String
     Dim wbBase As String
     wbBase = SafeFileName(GetWorkbookBaseName(ThisWorkbook.Name))
     GetDefaultExportStub = wbBase & "_VBA_EXPORT_INFO.txt"
+End Function
+
+Private Function PickImportFolder() As String
+    Dim dlg As Object
+
+    Set dlg = Application.FileDialog(DIALOG_FOLDER_PICKER)
+    With dlg
+        .Title = "Select folder containing .bas modules to import"
+        .AllowMultiSelect = False
+        If .Show <> -1 Then
+            PickImportFolder = vbNullString
+            Exit Function
+        End If
+        PickImportFolder = .SelectedItems(1)
+    End With
 End Function
 
 Private Function GetWorkbookBaseName(ByVal wbName As String) As String
@@ -224,9 +332,9 @@ End Function
 
 Private Function ComponentExtension(ByVal compType As Long) As String
     Select Case compType
-        Case 1: ComponentExtension = ".bas" ' Std module
-        Case 2: ComponentExtension = ".cls" ' Class module
-        Case 3: ComponentExtension = ".frm" ' UserForm
+        Case VB_COMP_STD_MODULE: ComponentExtension = ".bas" ' Std module
+        Case VB_COMP_CLASS_MODULE: ComponentExtension = ".cls" ' Class module
+        Case VB_COMP_USERFORM: ComponentExtension = ".frm" ' UserForm
         Case Else: ComponentExtension = vbNullString ' Document modules
     End Select
 End Function
@@ -248,6 +356,34 @@ Private Function CanAccessVBAProject() As Boolean
     Set test = ThisWorkbook.VBProject.VBComponents
     CanAccessVBAProject = (Err.Number = 0)
     Err.Clear
+End Function
+
+Private Sub LogHeader(ByVal procName As String, ByVal targetFolder As String)
+    Debug.Print "=== " & procName & " ==="
+    Debug.Print "Workbook: " & ThisWorkbook.Name
+    Debug.Print "Folder: " & targetFolder
+End Sub
+
+Private Sub RemoveStandardModuleIfExists(ByVal moduleName As String, ByRef vbComp As Object)
+    If StandardModuleExists(moduleName, vbComp) Then
+        ThisWorkbook.VBProject.VBComponents.Remove vbComp
+        Debug.Print "REMOVED: " & moduleName & " (existing standard module)"
+    End If
+End Sub
+
+Private Function StandardModuleExists(ByVal moduleName As String, ByRef vbComp As Object) As Boolean
+    Dim comp As Object
+
+    Set vbComp = Nothing
+    For Each comp In ThisWorkbook.VBProject.VBComponents
+        If comp.Type = VB_COMP_STD_MODULE Then
+            If StrComp(comp.Name, moduleName, vbTextCompare) = 0 Then
+                Set vbComp = comp
+                StandardModuleExists = True
+                Exit Function
+            End If
+        End If
+    Next comp
 End Function
 
 


### PR DESCRIPTION
### Motivation
- Consolidate import/export logic into a single, clearer module and remove magic numbers for VB component types. 
- Improve robustness and logging for importing `.bas` modules and make the export workflow friendlier for filesystem destinations (OneDrive/URL workarounds). 
- Provide safer behavior when importing modules by removing existing standard modules before import and notifying the user when no `.bas` files are present. 

### Description
- Renamed the module to `Dev_ImportExportVBAModules` and updated the module attribute to match. 
- Introduced constants `VB_COMP_STD_MODULE`, `VB_COMP_CLASS_MODULE`, `VB_COMP_USERFORM`, and `DIALOG_FOLDER_PICKER` to replace literal magic numbers. 
- Added public entry point `Import_All_BAS_Modules_FromFolder` which uses `PickImportFolder`, removes existing standard modules via `RemoveStandardModuleIfExists`, imports `.bas` files, logs successes/failures, and shows a user message when no `.bas` files are found. 
- Refactored shared helpers and logging: added `LogHeader`, `RemoveStandardModuleIfExists`, and `StandardModuleExists`, updated `ComponentExtension`, `PickImportFolder`, and `WriteExportInfo` to include import guidance. 

### Testing
- No automated tests were run because VBA macros cannot be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fccfec018832ba341ad0fb2a314a8)