### PR TITLE
Bump schema refs to 3.4.3 and normalize header comments

### DIFF
--- a/M_Core_Constants.bas
+++ b/M_Core_Constants.bas
@@ -7,9 +7,9 @@ Option Explicit
 '   Centralized constants for workbook metadata, sheet names, table names,
 '   key column names, audit column names, log levels, and shared messages.
 '   This module eliminates magic strings in code and keeps all naming aligned
-'   with Schema 3.2.0 (TBL_SCHEMA on SCHEMA tab).
+'   with Schema 3.4.3 (TBL_SCHEMA on SCHEMA tab).
 '
-' Inputs (tabs/tables/headers):
+' Inputs (Tabs/Tables/Headers):
 '   - None (this module does not read from the workbook).
 '
 ' Outputs / Side effects:
@@ -21,7 +21,7 @@ Option Explicit
 '       * Log levels and generic messages
 '
 ' Preconditions:
-'   - Schema 3.2.0 is the active, enforced schema in SCHEMA!TBL_SCHEMA.
+'   - Schema 3.4.3 is the active, enforced schema in SCHEMA!TBL_SCHEMA.
 '
 ' Postconditions:
 '   - None at runtime; this is a static configuration module.
@@ -39,7 +39,7 @@ Option Explicit
 '===============================================================================
 
 Public Const APP_VERSION      As String = "0.1.0"
-Public Const SCHEMA_VERSION   As String = "3.2.0"
+Public Const SCHEMA_VERSION   As String = "3.4.3"
 
 '===============================================================================
 ' Sheet (Tab) Names  - must match workbook tabs exactly

--- a/M_Core_Logging.bas
+++ b/M_Core_Logging.bas
@@ -6,11 +6,11 @@ Option Explicit
 '
 ' Purpose:
 '   Centralized logging utility for the Tracker workbook. Appends rows to
-'   Log.TBL_LOG using the schema defined in Schema 3.2.0. All modules should
+'   Log.TBL_LOG using the schema defined in Schema 3.4.3. All modules should
 '   call LogEvent (or the LogInfo/LogWarn/LogError wrappers) instead of
 '   writing to the log table directly.
 '
-' Inputs (Tabs/Tables/Columns):
+' Inputs (Tabs/Tables/Headers):
 '   - Sheet:  SH_LOG
 '   - Table:  TBL_LOG
 '   - Columns (from M_Core_Constants):
@@ -27,7 +27,7 @@ Option Explicit
 '       COL_LOG_VERSION
 '       COL_LOG_OTHER
 '
-' Outputs / Side Effects:
+' Outputs / Side effects:
 '   - Appends a single row to Log.TBL_LOG for each call to LogEvent.
 '   - Does not modify any other tables or sheets.
 '

--- a/M_Core_Tests.bas
+++ b/M_Core_Tests.bas
@@ -11,7 +11,7 @@ Option Explicit
 '     - Table (ListObject) name constants (TBL_*)
 '     - A small set of key column names on core tables
 '
-' Inputs (Tabs/Tables/Columns):
+' Inputs (Tabs/Tables/Headers):
 '   - Uses ThisWorkbook.Worksheets and ListObjects to discover actual sheets
 '     and tables.
 '   - Uses constants defined in M_Core_Constants:
@@ -30,7 +30,7 @@ Option Explicit
 '
 ' Preconditions:
 '   - M_Core_Constants module is present and compiled.
-'   - Workbook is expected to conform to Schema 3.2.0.
+'   - Workbook is expected to conform to Schema 3.4.3.
 '
 ' Postconditions:
 '   - Does not modify business data; only writes the Core_Tests sheet.

--- a/M_Data_Comps_Entry.bas
+++ b/M_Data_Comps_Entry.bas
@@ -6,8 +6,7 @@ Option Explicit
 '
 ' Purpose:
 '   Create a new Component record in Comps.TBL_COMPS with:
-'     - Gate check (blocks if workbook not ready) / 
-'    - this is just a modification for the sake of having a modification so the PR Button appears...
+'     - Gate check (blocks if workbook not ready)
 '     - Required-field prompting (ComponentDescription REQUIRED)
 '     - Forced-valid Supplier selection (search by SupplierName; forgiving matching)
 '     - Supplier picker shows numbered options when multiple matches


### PR DESCRIPTION
### Motivation
- Upgrade the workbook schema references from 3.2.0 to 3.4.3 to reflect the current enforced schema.
- Make header comment labels consistent across modules by standardizing `Inputs`/`Outputs` wording and replacing "Columns" with "Headers" where appropriate.
- Remove a non-production placeholder comment in the component entry documentation to keep module headers production-ready.

### Description
- Updated `SCHEMA_VERSION` constant to `"3.4.3"` and replaced references to Schema 3.2.0 with 3.4.3 in `M_Core_Constants.bas`.
- Updated the logging module header in `M_Core_Logging.bas` to reference Schema 3.4.3 and standardized header labels to `Inputs (Tabs/Tables/Headers)` and `Outputs / Side effects`.
- Updated `M_Core_Tests.bas` header to use `Inputs (Tabs/Tables/Headers)` and reference Schema 3.4.3.
- Removed the non-production / placeholder line from the header of `M_Data_Comps_Entry.bas` and left other module documentation intact.

### Testing
- Searched the codebase for legacy schema tokens using `rg -n "3\.2\.0|Schema 3\.2\.0|SCHEMA_VERSION"` and used that output to drive edits, which completed successfully.
- Verified file changes by inspecting the updated files with `nl`/file reads to confirm the textual replacements and `SCHEMA_VERSION` change were applied.
- No automated unit or integration tests were run because this PR only modifies header comments and a schema constant; edits were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69829b544f6c832b8da126b6b6239ebe)