### PR TITLE
Add BOM naming constants, use them in BOM creation, and document convention

### DIFF
--- a/M_Core_Constants.bas
+++ b/M_Core_Constants.bas
@@ -86,6 +86,15 @@ Public Const TBL_BOM_PDM001   As String = "TBL_BOM_PDM001"
 Public Const TBL_BOM_TEMPLATE As String = "TBL_BOM_TEMPLATE"
 
 '===============================================================================
+' BOM Naming Conventions
+'===============================================================================
+
+Public Const BOM_SHEET_PREFIX As String = "BOM_"
+Public Const BOM_TABLE_PREFIX As String = "TBL_BOM_"
+Public Const BOM_ID_PREFIX    As String = "BOM-"
+Public Const BOM_ID_PAD       As Long = 4
+
+'===============================================================================
 ' Common Column Names - Keys / IDs
 '===============================================================================
 

--- a/M_Data_BOMs_Entry.bas
+++ b/M_Data_BOMs_Entry.bas
@@ -44,19 +44,6 @@ Option Explicit
 Public Sub UI_Create_BOM_For_Assembly()
     Const PROC_NAME As String = "M_Data_BOMs_Entry.UI_Create_BOM_For_Assembly"
 
-    Const SH_TEMPLATE As String = "BOM_TEMPLATE"
-    Const LO_TEMPLATE As String = "TBL_BOM_TEMPLATE"
-
-    Const SH_BOMS As String = "BOMS"
-    Const LO_BOMS As String = "TBL_BOMS"
-
-    Const SH_COMPS As String = "Comps"
-    Const LO_COMPS As String = "TBL_COMPS"
-
-    Const BOM_TAB_PREFIX As String = "BOM_BUILD_"
-    Const BOM_ID_PREFIX As String = "BOM-"
-    Const BOM_ID_PAD As Long = 4
-
     Dim wb As Workbook
     Dim wsTemplate As Worksheet
     Dim wsBoms As Worksheet
@@ -81,13 +68,13 @@ Public Sub UI_Create_BOM_For_Assembly()
     If Not GateReady_Safe(True) Then Exit Sub
 
     Set wb = ThisWorkbook
-    Set wsTemplate = wb.Worksheets(SH_TEMPLATE)
+    Set wsTemplate = wb.Worksheets(SH_BOM_TEMPLATE)
     Set wsBoms = wb.Worksheets(SH_BOMS)
     Set wsComps = wb.Worksheets(SH_COMPS)
 
-    Set loTemplate = wsTemplate.ListObjects(LO_TEMPLATE)
-    Set loBoms = wsBoms.ListObjects(LO_BOMS)
-    Set loComps = wsComps.ListObjects(LO_COMPS)
+    Set loTemplate = wsTemplate.ListObjects(TBL_BOM_TEMPLATE)
+    Set loBoms = wsBoms.ListObjects(TBL_BOMS)
+    Set loComps = wsComps.ListObjects(TBL_COMPS)
 
     ' Guard required headers
     RequireColumn loTemplate, "CompID"
@@ -128,11 +115,11 @@ Public Sub UI_Create_BOM_For_Assembly()
     wsTemplate.Copy After:=wb.Sheets(wb.Sheets.Count)
     Set wsNew = ActiveSheet
 
-    newSheetName = BuildUniqueSheetName(wb, BOM_TAB_PREFIX & assemblyId)
+    newSheetName = BuildUniqueSheetName(wb, BOM_SHEET_PREFIX & assemblyId)
     wsNew.Name = newSheetName
 
     Set loNew = wsNew.ListObjects(1)
-    newTableName = BuildUniqueTableName(wb, "TBL_BOM_" & NormalizeName(assemblyId))
+    newTableName = BuildUniqueTableName(wb, BOM_TABLE_PREFIX & NormalizeName(assemblyId))
     loNew.Name = newTableName
 
     ' Register in BOMS table

--- a/combined.md
+++ b/combined.md
@@ -160,6 +160,26 @@ Naming & Style Conventions:
 
 \- Buttons/Shapes: BTN\_ (BTN_Generate_PO, BTN_Recalc_Demand).
 
+**BOM Naming Convention (copy/paste for 050 Workbook Strategy)**
+
+```
+BOM Naming Convention (Schema 3.4.3+)
+
+1) BOM worksheet (tab) name:
+   BOM_<AssemblyID>
+
+2) BOM table (ListObject) name:
+   TBL_BOM_<AssemblyID>
+
+3) BOMID (BOMS table):
+   BOM-#### (zero-padded numeric sequence, e.g., BOM-0001)
+
+Notes:
+- <AssemblyID> is the CompID of the buildable top assembly.
+- Illegal Excel sheet characters (/:*?[]\) are normalized, and long names are truncated to 31 chars.
+- The BOM worksheet and table names are derived from AssemblyID; BOMID is a separate ID stored in BOMS.TBL_BOMS.
+```
+
 Workbook Schema (Required Contract):
 
 Examples of required core tables include TBL_SUPPLIERS, TBL_COMPS, TBL_SCHEMA, TBL_AUTOMATION, TBL_HELPERS, TBL_BOM\_\[TA PN\], TBL_BOMS, TBL_WOS, TBL_DEMAND, TBL_PO_LINES, TBL_PO_HEADERS, TBL_INV, TBL_LOG, TBL_USERS. Their detailed structure is defined in the Workbook Strategy (050).
@@ -1118,7 +1138,7 @@ Supplier Name of Supplier
 
 AssemblyID
 
-BomID Unique identifier for each BOM, defined as that which follows BOM\_ on any worksheet tab
+BomID Unique identifier for each BOM, stored in BOMS as BOM-#### (zero-padded numeric sequence)
 
 OurPN Internal Part Number
 
@@ -1183,7 +1203,7 @@ For Reference and filling in some gaps: Overview of Workbook-User Interaction.
 
 Users begin by creating **Supplier** records, followed by **Component** records. Each component references an existing supplier and is uniquely identified by a PN + Revision combination. Components and suppliers may be inactivated to prevent future use while retaining historical data.
 
-Users then define **Top Assemblies (TAs)** by creating Bills of Material (BOMs). Each TA is represented by a worksheet named BOM\_\<TA Name\> created from a template and contains a table listing required components (PN + Revision) and quantities per assembly. A BOM may include multiple instances of the same PN, at the same or different revisions. Once a TA is referenced by a Work Order, the BOM worksheet name becomes fixed, but BOM contents may still be edited.
+Users then define **Top Assemblies (TAs)** by creating Bills of Material (BOMs). Each TA is represented by a worksheet named BOM\_\<AssemblyID\> created from a template and contains a table named TBL_BOM\_\<AssemblyID\> listing required components (PN + Revision) and quantities per assembly. A BOM may include multiple instances of the same PN, at the same or different revisions. Once a TA is referenced by a Work Order, the BOM worksheet name becomes fixed, but BOM contents may still be edited.
 
 Users create **Work Orders (WOs)** by selecting a TA, entering a build quantity and due date. Upon WO creation, and whenever a referenced BOM is edited, the system calculates component demand by PN + Revision based on BOM quantities and WO quantities. Demand is reported both per open WO and as an aggregated total across all open WOs. WOs always reference the current state of a BOM; BOM changes intentionally propagate to existing WOs by updating demand. Allocation priority between WOs is managed manually by the user.
 


### PR DESCRIPTION
### Motivation
- Centralize BOM naming rules so code, generated sheets/tables, and documentation stay in sync.
- Remove literal prefixes scattered in code to reduce drift and simplify future renaming.
- Provide a copy/pasteable convention snippet for the 050 Workbook Strategy to keep docs and implementation aligned.

### Description
- Added BOM naming constants to `M_Core_Constants.bas`: `BOM_SHEET_PREFIX`, `BOM_TABLE_PREFIX`, `BOM_ID_PREFIX`, and `BOM_ID_PAD` to define sheet/table prefixes and BOM ID formatting.
- Updated `M_Data_BOMs_Entry.bas` to consume those constants (replaced local literals like `BOM_TAB_PREFIX`, table name strings, and `BOM_ID` generation parameters with the shared constants) so new BOM worksheets and ListObject names are produced from `BOM_SHEET_PREFIX` and `BOM_TABLE_PREFIX` and IDs use `BOM_ID_PREFIX`/`BOM_ID_PAD`.
- Updated `combined.md` to include a copy/paste block titled "BOM Naming Convention" documenting the worksheet name (`BOM_<AssemblyID>`), table name (`TBL_BOM_<AssemblyID>`), BOMID format (`BOM-####`), and glossary/workflow text to reference `AssemblyID` and `TBL_BOM_<AssemblyID>`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e3f1b44c832b8af3195b1be1326e)