### PR TITLE
Fix duplicate component entrypoint name

### DIFF
--- a/M_Data_Comps_Entry.bas
+++ b/M_Data_Comps_Entry.bas
@@ -57,11 +57,11 @@ Option Explicit
 ' PUBLIC ENTRY POINTS
 '==========================
 Public Sub NewComponent()
-    UI_New_Component
+    RunNewComponent
 End Sub
 
-Public Sub UI_New_Component()
-    Const PROC_NAME As String = "M_Data_Comps_Entry.UI_New_Component"
+Private Sub RunNewComponent()
+    Const PROC_NAME As String = "M_Data_Comps_Entry.RunNewComponent"
 
     Const SH_COMPS As String = "Comps"
     Const LO_COMPS As String = "TBL_COMPS"


### PR DESCRIPTION
### Motivation
- Avoid an ambiguous public macro name collision in the workbook by removing the duplicate `UI_New_Component` public entrypoint so there is a single clear UI-facing entrypoint.

### Description
- In `M_Data_Comps_Entry.bas` the original public `UI_New_Component` was converted to a `Private Sub RunNewComponent()` and the public wrapper `NewComponent` was updated to call `RunNewComponent`, preserving `NewComponent` as the UI-facing macro.

### Testing
- Ran an automated Python scanner that searches for `Public Sub/Function` definitions before and after the change and confirmed the duplicate `UI_New_Component` definition is resolved; no runtime VBA macro execution was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4f94d6ac832b883660e3ba50d4da)