### PR TITLE
Fix component picker BOM table access

### DIFF
--- a/UF_ComponentPicker.frm
+++ b/UF_ComponentPicker.frm
@@ -155,7 +155,7 @@ Private Sub cmdAdd_Click()
     End If
 
     Dim loBom As ListObject
-    Set loBom = M_Data_BOMs_Picker.GetActiveBomTable_Picker()
+    Set loBom = M_Data_BOMs_Picker.GetActiveBomTable_Public()
 
     Dim i As Long
     Dim added As Long


### PR DESCRIPTION
### Motivation
- Resolve a runtime compiler error in `UF_ComponentPicker` caused by an undefined BOM accessor by using the module's public accessor.

### Description
- Replace the call to the non-existent `GetActiveBomTable_Picker` with `M_Data_BOMs_Picker.GetActiveBomTable_Public()` in `UF_ComponentPicker.frm` so the form obtains the active BOM table via the provided public wrapper.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7149f480832b88a0915c1d7830c5)