### PR TITLE
Use default component picker instance and public BOM accessor

### DIFF
--- a/M_Data_BOMs_Picker.bas
+++ b/M_Data_BOMs_Picker.bas
@@ -100,10 +100,10 @@ Public Sub UI_Open_ComponentPicker_Form()
 
     If Not GateReady_Safe(True) Then Exit Sub
 
-    Dim frm As UF_ComponentPicker
-    Set frm = New UF_ComponentPicker
-    frm.InitForm ThisWorkbook
-    frm.Show vbModal
+    With UF_ComponentPicker
+        .InitForm ThisWorkbook
+        .Show vbModal
+    End With
     Exit Sub
 
 EH:

--- a/UF_ComponentPicker.frm
+++ b/UF_ComponentPicker.frm
@@ -155,7 +155,7 @@ Private Sub cmdAdd_Click()
     End If
 
     Dim loBom As ListObject
-    Set loBom = M_Data_BOMs_Picker.GetActiveBomTable_Picker()
+    Set loBom = M_Data_BOMs_Picker.GetActiveBomTable_Public()
 
     Dim i As Long
     Dim added As Long


### PR DESCRIPTION
### Motivation
- Fix a runtime/VBE compatibility issue where the component picker was instantiated as a form class which is unsupported in the VBE environment.  
- Resolve a missing/incorrect BOM table accessor by calling the module's public accessor so the picker can obtain the active BOM safely.

### Description
- Replace explicit instantiation of the UserForm in `UI_Open_ComponentPicker_Form` with the default UserForm instance by using `With UF_ComponentPicker` and calling `.InitForm`/`.Show` in `M_Data_BOMs_Picker.bas`.
- Update the component-adding logic in `UF_ComponentPicker.frm` to call `M_Data_BOMs_Picker.GetActiveBomTable_Public()` instead of the non-existent `GetActiveBomTable_Picker()` so the form obtains the active BOM via the module's public API.
- Minor form file normalization/whitespace changes applied to `UF_ComponentPicker.frm` as part of the edit.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7149f480832b88a0915c1d7830c5)