### PR TITLE
Populate TA description on new BOM sheets

### DIFF
--- a/M_Data_BOMs_Entry.bas
+++ b/M_Data_BOMs_Entry.bas
@@ -201,6 +201,9 @@ Public Sub Create_BOM_For_Assembly_FromInputs( _
 660 newTableName = BuildUniqueTableName(wb, "TBL_BOM_" & NormalizeName(taId))
 670 loNew.Name = newTableName
 
+    ' Populate TA Description field on new BOM sheet
+675 wsNew.Range("C4").Value = taDesc
+
     ' Register in BOMS table
 680 Dim lr As ListRow
 690 Set lr = loBoms.ListRows.Add


### PR DESCRIPTION
### Motivation
- Ensure the top-assembly description entered via the BOM creation dialog (`TADesc`) is reflected on the created BOM sheet's visible TA Description cell (`C4`) in addition to being stored in `BOM_NOTES`.

### Description
- Added `wsNew.Range("C4").Value = taDesc` to `Create_BOM_For_Assembly_FromInputs` in `M_Data_BOMs_Entry.bas`, placed after the new sheet/table are created and named, while leaving the existing `BOM_NOTES` registration unchanged.

### Testing
- Applied the patch and verified the change and commit with `git diff -- M_Data_BOMs_Entry.bas`, `git status --short`, and `git log -1 --oneline`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f7c05460832bb361747da86bb7fb)