### PR TITLE
Add shared BOM status helpers and enforce BOM edit guards

### DIFF
--- a/M_Core_Constants.bas
+++ b/M_Core_Constants.bas
@@ -102,6 +102,7 @@ Public Const COL_USER_NAME        As String = "UserName"
 Public Const COL_TRANSACTION_ID   As String = "TransactionID"
 
 Public Const COL_BOM_ID           As String = "BOMID"
+Public Const COL_BOM_STATUS       As String = "BOMStatus"
 Public Const COL_ASSEMBLY_ID      As String = "AssemblyID"
 Public Const COL_TAID             As String = "TAID"
 
@@ -161,6 +162,14 @@ Public Const COL_BUILD_QTY_DEMAND As String = "BuildQuantityDemand"
 Public Const COL_PO_QTY           As String = "POQuantity"
 Public Const COL_PRICE_PER_UOM    As String = "PricePerUOM"
 Public Const COL_PO_LINE_TOTAL    As String = "POLineTotal"
+
+'===============================================================================
+' BOM lifecycle statuses
+'===============================================================================
+
+Public Const BOM_STATUS_DRAFT     As String = "DRAFT"
+Public Const BOM_STATUS_LOCK      As String = "LOCK"
+Public Const BOM_STATUS_OBSOLETE  As String = "OBSOLETE"
 
 '===============================================================================
 ' Log Levels

--- a/M_Data_BOMs_AddComponents.bas
+++ b/M_Data_BOMs_AddComponents.bas
@@ -55,6 +55,7 @@ Public Sub UI_Add_Components_To_BOM()
     Dim loBom As ListObject
     Dim loComps As ListObject
 
+    Dim bomId As String
     Dim pn As String, rev As String
     Dim qtyPer As Double
 
@@ -69,6 +70,16 @@ Public Sub UI_Add_Components_To_BOM()
     If wsBom.ListObjects.Count < 1 Then Err.Raise vbObjectError + 7001, PROC_NAME, "Active sheet has no table (ListObject)."
 
     Set loBom = wsBom.ListObjects(1)
+
+    bomId = M_Data_BOMs_Status.GetBomIdByTabName(wsBom.Name)
+    If Len(bomId) = 0 Then
+        MsgBox "Could not resolve BOMID for sheet '" & wsBom.Name & "'.", vbExclamation, "Add Components to BOM"
+        Exit Sub
+    End If
+    If Not M_Data_BOMs_Status.CanEditBom(bomId) Then
+        MsgBox M_Data_BOMs_Status.GetBomEditDisabledMessage(bomId), vbExclamation, "Add Components to BOM"
+        Exit Sub
+    End If
 
     ' BOM required headers
     RequireColumn loBom, "CompID"

--- a/M_Data_BOMs_Entry.bas
+++ b/M_Data_BOMs_Entry.bas
@@ -239,6 +239,11 @@ SetByHeader loBoms, lr, "BOM_NOTES", bomNotes
 If ColumnExists(loBoms, "TARev") Then SetByHeader loBoms, lr, "TARev", taRev
 If ColumnExists(loBoms, "TADesc") Then SetByHeader loBoms, lr, "TADesc", taDesc
 If ColumnExists(loBoms, "TAPN") Then SetByHeader loBoms, lr, "TAPN", taPn
+If ColumnExists(loBoms, M_Core_Constants.COL_BOM_STATUS) Then
+    SetByHeader loBoms, lr, M_Core_Constants.COL_BOM_STATUS, M_Core_Constants.BOM_STATUS_DRAFT
+ElseIf ColumnExists(loBoms, "Status") Then
+    SetByHeader loBoms, lr, "Status", M_Core_Constants.BOM_STATUS_DRAFT
+End If
 
 If ColumnExists(loBoms, "CreatedAt") Then SetByHeader loBoms, lr, "CreatedAt", createdAt
 If ColumnExists(loBoms, "CreatedBy") Then SetByHeader loBoms, lr, "CreatedBy", createdBy

--- a/M_Data_BOMs_Picker.bas
+++ b/M_Data_BOMs_Picker.bas
@@ -157,6 +157,7 @@ Public Sub AddComponentToActiveBOM(ByVal pn As String, ByVal rev As String, ByVa
     Dim wsComps As Worksheet
     Dim loComps As ListObject
 
+    Dim bomId As String
     Dim compId As String, desc As String, uom As String, notes As String
 
     On Error GoTo EH
@@ -168,6 +169,17 @@ Public Sub AddComponentToActiveBOM(ByVal pn As String, ByVal rev As String, ByVa
 
     Set wb = ThisWorkbook
     Set loBom = ResolveTargetTable(wb, PickerTarget_BOM)
+
+    bomId = M_Data_BOMs_Status.GetBomIdByTabName(loBom.Parent.Name)
+    If Len(bomId) = 0 Then
+        MsgBox "Could not resolve BOMID for active BOM sheet.", vbExclamation, "Component Picker"
+        Exit Sub
+    End If
+    If Not M_Data_BOMs_Status.CanEditBom(bomId) Then
+        MsgBox M_Data_BOMs_Status.GetBomEditDisabledMessage(bomId), vbExclamation, "Component Picker"
+        Exit Sub
+    End If
+
     Set wsComps = wb.Worksheets(SH_COMPS)
     Set loComps = wsComps.ListObjects(LO_COMPS)
 
@@ -238,12 +250,25 @@ Private Sub AddPickedRowsToTarget(ByVal wb As Workbook, ByVal loPick As ListObje
 
     Dim compId As String, pn As String, rev As String, desc As String, uom As String, notes As String, rs As String
     Dim qtyVal As Double
+    Dim bomId As String
 
     On Error GoTo EH
 
     ValidateUniqueActiveMappings wb
 
     Set loTarget = ResolveTargetTable(wb, targetContext)
+
+    If targetContext = PickerTarget_BOM Then
+        bomId = M_Data_BOMs_Status.GetBomIdByTabName(loTarget.Parent.Name)
+        If Len(bomId) = 0 Then
+            MsgBox "Could not resolve BOMID for active BOM sheet.", vbExclamation, "Component Picker"
+            Exit Sub
+        End If
+        If Not M_Data_BOMs_Status.CanEditBom(bomId) Then
+            MsgBox M_Data_BOMs_Status.GetBomEditDisabledMessage(bomId), vbExclamation, "Component Picker"
+            Exit Sub
+        End If
+    End If
 
     For i = 1 To rowIndices.Count
         pickRowIndex = CLng(rowIndices(i))

--- a/M_Data_BOMs_Status.bas
+++ b/M_Data_BOMs_Status.bas
@@ -1,0 +1,232 @@
+Attribute VB_Name = "M_Data_BOMs_Status"
+Option Explicit
+
+Public Function GetBomStatus(ByVal bomId As String) As String
+    Dim wb As Workbook
+    Dim wsBoms As Worksheet
+    Dim loBoms As ListObject
+    Dim rowIndex As Long
+    Dim idxStatus As Long
+    Dim statusVal As String
+
+    GetBomStatus = vbNullString
+    bomId = Trim$(bomId)
+    If Len(bomId) = 0 Then Exit Function
+
+    On Error GoTo CleanFail
+
+    Set wb = ThisWorkbook
+    Set wsBoms = wb.Worksheets(M_Core_Constants.SH_BOMS)
+    Set loBoms = wsBoms.ListObjects(M_Core_Constants.TBL_BOMS)
+
+    rowIndex = FindBomRowIndex(loBoms, bomId)
+    If rowIndex = 0 Then Exit Function
+
+    idxStatus = ResolveBomStatusColumnIndex(loBoms)
+    If idxStatus = 0 Then
+        GetBomStatus = M_Core_Constants.BOM_STATUS_DRAFT
+        Exit Function
+    End If
+
+    statusVal = SafeText(loBoms.ListColumns(idxStatus).DataBodyRange.Cells(rowIndex, 1).Value)
+    If Len(statusVal) = 0 Then statusVal = M_Core_Constants.BOM_STATUS_DRAFT
+
+    GetBomStatus = NormalizeBomStatus(statusVal)
+    Exit Function
+
+CleanFail:
+    GetBomStatus = vbNullString
+End Function
+
+Public Function CanEditBom(ByVal bomId As String) As Boolean
+    Dim statusVal As String
+    statusVal = GetBomStatus(bomId)
+    CanEditBom = (StrComp(statusVal, M_Core_Constants.BOM_STATUS_DRAFT, vbTextCompare) = 0)
+End Function
+
+Public Function CanBuildBom(ByVal bomId As String) As Boolean
+    Dim statusVal As String
+    statusVal = GetBomStatus(bomId)
+
+    CanBuildBom = (StrComp(statusVal, M_Core_Constants.BOM_STATUS_DRAFT, vbTextCompare) = 0 Or _
+                   StrComp(statusVal, M_Core_Constants.BOM_STATUS_LOCK, vbTextCompare) = 0)
+End Function
+
+Public Function ValidateBomStatusTransition(ByVal oldStatus As String, ByVal newStatus As String, ByVal role As String) As Boolean
+    Dim oldNorm As String
+    Dim newNorm As String
+    Dim roleNorm As String
+
+    oldNorm = NormalizeBomStatus(oldStatus)
+    newNorm = NormalizeBomStatus(newStatus)
+    roleNorm = UCase$(Trim$(role))
+
+    ValidateBomStatusTransition = False
+
+    If Len(oldNorm) = 0 Or Len(newNorm) = 0 Then
+        MsgBox "Invalid BOM status transition: unknown status value.", vbExclamation, "BOM Status"
+        Exit Function
+    End If
+
+    If StrComp(oldNorm, newNorm, vbTextCompare) = 0 Then
+        ValidateBomStatusTransition = True
+        Exit Function
+    End If
+
+    Select Case oldNorm
+        Case M_Core_Constants.BOM_STATUS_DRAFT
+            ValidateBomStatusTransition = (StrComp(newNorm, M_Core_Constants.BOM_STATUS_LOCK, vbTextCompare) = 0 Or _
+                                           StrComp(newNorm, M_Core_Constants.BOM_STATUS_OBSOLETE, vbTextCompare) = 0)
+
+        Case M_Core_Constants.BOM_STATUS_LOCK
+            If IsBomAdminRole(roleNorm) Then
+                ValidateBomStatusTransition = (StrComp(newNorm, M_Core_Constants.BOM_STATUS_DRAFT, vbTextCompare) = 0 Or _
+                                               StrComp(newNorm, M_Core_Constants.BOM_STATUS_OBSOLETE, vbTextCompare) = 0)
+            Else
+                ValidateBomStatusTransition = (StrComp(newNorm, M_Core_Constants.BOM_STATUS_OBSOLETE, vbTextCompare) = 0)
+            End If
+
+        Case M_Core_Constants.BOM_STATUS_OBSOLETE
+            If IsBomAdminRole(roleNorm) Then
+                ValidateBomStatusTransition = (StrComp(newNorm, M_Core_Constants.BOM_STATUS_DRAFT, vbTextCompare) = 0 Or _
+                                               StrComp(newNorm, M_Core_Constants.BOM_STATUS_LOCK, vbTextCompare) = 0)
+            Else
+                ValidateBomStatusTransition = False
+            End If
+    End Select
+
+    If Not ValidateBomStatusTransition Then
+        MsgBox "Status transition blocked: " & oldNorm & " -> " & newNorm & _
+               ". Role '" & role & "' is not permitted.", vbExclamation, "BOM Status"
+    End If
+End Function
+
+Public Function GetBomIdByTabName(ByVal bomTabName As String) As String
+    Dim wb As Workbook
+    Dim wsBoms As Worksheet
+    Dim loBoms As ListObject
+    Dim idxBomId As Long
+    Dim idxBomTab As Long
+    Dim arrBomId As Variant
+    Dim arrBomTab As Variant
+    Dim i As Long
+
+    GetBomIdByTabName = vbNullString
+    bomTabName = Trim$(bomTabName)
+    If Len(bomTabName) = 0 Then Exit Function
+
+    On Error GoTo CleanFail
+
+    Set wb = ThisWorkbook
+    Set wsBoms = wb.Worksheets(M_Core_Constants.SH_BOMS)
+    Set loBoms = wsBoms.ListObjects(M_Core_Constants.TBL_BOMS)
+
+    If loBoms.DataBodyRange Is Nothing Then Exit Function
+
+    idxBomId = GetColIndex(loBoms, M_Core_Constants.COL_BOM_ID)
+    idxBomTab = GetColIndex(loBoms, "BOMTab")
+    If idxBomId = 0 Or idxBomTab = 0 Then Exit Function
+
+    arrBomId = loBoms.ListColumns(idxBomId).DataBodyRange.Value
+    arrBomTab = loBoms.ListColumns(idxBomTab).DataBodyRange.Value
+
+    For i = 1 To UBound(arrBomTab, 1)
+        If StrComp(SafeText(arrBomTab(i, 1)), bomTabName, vbTextCompare) = 0 Then
+            GetBomIdByTabName = SafeText(arrBomId(i, 1))
+            Exit Function
+        End If
+    Next i
+    Exit Function
+
+CleanFail:
+    GetBomIdByTabName = vbNullString
+End Function
+
+Public Function GetBomEditDisabledMessage(ByVal bomId As String) As String
+    Dim statusVal As String
+
+    statusVal = GetBomStatus(bomId)
+    If Len(statusVal) = 0 Then
+        GetBomEditDisabledMessage = "Unable to determine BOM status; edits are disabled."
+        Exit Function
+    End If
+
+    If StrComp(statusVal, M_Core_Constants.BOM_STATUS_LOCK, vbTextCompare) = 0 Then
+        GetBomEditDisabledMessage = "BOM is LOCK; edits are disabled"
+    ElseIf StrComp(statusVal, M_Core_Constants.BOM_STATUS_OBSOLETE, vbTextCompare) = 0 Then
+        GetBomEditDisabledMessage = "BOM is OBSOLETE; edits are disabled"
+    Else
+        GetBomEditDisabledMessage = "BOM status '" & statusVal & "' does not allow edits."
+    End If
+End Function
+
+Private Function FindBomRowIndex(ByVal loBoms As ListObject, ByVal bomId As String) As Long
+    Dim idxBomId As Long
+    Dim arrBomId As Variant
+    Dim i As Long
+
+    FindBomRowIndex = 0
+    If loBoms Is Nothing Then Exit Function
+    If loBoms.DataBodyRange Is Nothing Then Exit Function
+
+    idxBomId = GetColIndex(loBoms, M_Core_Constants.COL_BOM_ID)
+    If idxBomId = 0 Then Exit Function
+
+    arrBomId = loBoms.ListColumns(idxBomId).DataBodyRange.Value
+    For i = 1 To UBound(arrBomId, 1)
+        If StrComp(SafeText(arrBomId(i, 1)), bomId, vbTextCompare) = 0 Then
+            FindBomRowIndex = i
+            Exit Function
+        End If
+    Next i
+End Function
+
+Private Function ResolveBomStatusColumnIndex(ByVal loBoms As ListObject) As Long
+    ResolveBomStatusColumnIndex = GetColIndex(loBoms, M_Core_Constants.COL_BOM_STATUS)
+    If ResolveBomStatusColumnIndex = 0 Then
+        ResolveBomStatusColumnIndex = GetColIndex(loBoms, "Status")
+    End If
+End Function
+
+Private Function NormalizeBomStatus(ByVal statusVal As String) As String
+    Dim s As String
+    s = UCase$(Trim$(statusVal))
+
+    Select Case s
+        Case UCase$(M_Core_Constants.BOM_STATUS_DRAFT)
+            NormalizeBomStatus = M_Core_Constants.BOM_STATUS_DRAFT
+        Case UCase$(M_Core_Constants.BOM_STATUS_LOCK)
+            NormalizeBomStatus = M_Core_Constants.BOM_STATUS_LOCK
+        Case UCase$(M_Core_Constants.BOM_STATUS_OBSOLETE)
+            NormalizeBomStatus = M_Core_Constants.BOM_STATUS_OBSOLETE
+        Case Else
+            NormalizeBomStatus = vbNullString
+    End Select
+End Function
+
+Private Function IsBomAdminRole(ByVal roleNorm As String) As Boolean
+    IsBomAdminRole = (roleNorm = "ADMIN" Or roleNorm = "ENGINEER")
+End Function
+
+Private Function GetColIndex(ByVal lo As ListObject, ByVal header As String) As Long
+    Dim lc As ListColumn
+
+    For Each lc In lo.ListColumns
+        If StrComp(lc.Name, header, vbTextCompare) = 0 Then
+            GetColIndex = lc.Index
+            Exit Function
+        End If
+    Next lc
+
+    GetColIndex = 0
+End Function
+
+Private Function SafeText(ByVal v As Variant) As String
+    If IsError(v) Then
+        SafeText = vbNullString
+    ElseIf IsNull(v) Then
+        SafeText = vbNullString
+    Else
+        SafeText = Trim$(CStr(v))
+    End If
+End Function


### PR DESCRIPTION
### Motivation
- Centralize BOM lifecycle state and enforcement so multiple BOM mutation paths share the same status semantics and messages.
- Prevent accidental edits to BOMs that are locked or obsolete and make new BOM creation explicitly default to a safe `DRAFT` status.

### Description
- Added shared constants in `M_Core_Constants.bas`: `COL_BOM_STATUS`, `BOM_STATUS_DRAFT`, `BOM_STATUS_LOCK`, and `BOM_STATUS_OBSOLETE`.
- Introduced a new module `M_Data_BOMs_Status.bas` that provides `GetBomStatus`, `CanEditBom`, `CanBuildBom`, `ValidateBomStatusTransition`, `GetBomIdByTabName`, and `GetBomEditDisabledMessage` plus helpers for resolving/normalizing status columns.
- Updated BOM creation in `M_Data_BOMs_Entry.bas` to set the BOM status to `DRAFT` when `BOMStatus` (or legacy `Status`) exists on `TBL_BOMS` by default.
- Enforced edit guards in mutation paths by resolving BOM tab → BOMID and checking `CanEditBom` before writes in `M_Data_BOMs_AddComponents.bas` (`UI_Add_Components_To_BOM`) and `M_Data_BOMs_Picker.bas` (both `AddComponentToActiveBOM` and picker bulk add path), returning clear messages like `BOM is LOCK; edits are disabled` when blocked.

### Testing
- Verified helper signatures and constants exist by searching for `GetBomStatus`, `CanEditBom`, `CanBuildBom`, `ValidateBomStatusTransition`, `BOM_STATUS_(DRAFT|LOCK|OBSOLETE)`, and `COL_BOM_STATUS`, and confirmed matches were found (successful).
- Validated edit-block messaging by searching for the new messages and `GetBomEditDisabledMessage` usages and confirmed the mutation paths reference them (successful).
- Inspected diffs of modified files (`M_Core_Constants.bas`, `M_Data_BOMs_Status.bas`, `M_Data_BOMs_Entry.bas`, `M_Data_BOMs_AddComponents.bas`, `M_Data_BOMs_Picker.bas`) to ensure intended changes were applied (successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a4162b84832b8e96fc2c846045dd)