### PR TITLE
Add AGENTS.md defaults for task planning workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Purpose
+These instructions define how Codex should propose and execute code-change plans in this repository.
+
+## Default planning behavior
+When proposing work, always provide a structured task list using this template for each task:
+
+- **Task**
+- **Why**
+- **Depends on**
+- **Risk level** (`low` / `medium` / `high`)
+- **How to verify**
+- **Can skip?** (`yes/no` + consequence)
+
+## Execution guidance
+- Treat tasks as a plan, not a batch script.
+- Default to running tasks **one at a time**.
+- Default to running tasks **in order** unless explicitly marked independent.
+- Clearly label dependencies and prerequisites.
+- If a task is skipped, explicitly state downstream impact before continuing.
+
+## Validation expectations
+- After each meaningful task, run a targeted validation step (tests, lint, build, or focused checks).
+- Prefer incremental verification over end-only verification.
+
+## Change management
+- Prefer small, logically scoped commits.
+- Keep high-risk changes isolated from low-risk refactors when possible.
+
+## Communication style
+- Be concise but explicit about assumptions, dependencies, and risk.
+- If uncertainty exists, present recommended order and a safe fallback path.


### PR DESCRIPTION
### Motivation
- Provide persistent repository-level guidance for how Codex should propose and execute code-change plans, including a small task-template and execution/validation defaults.

### Description
- Add new `AGENTS.md` that defines a structured task proposal template (`Task`, `Why`, `Depends on`, `Risk level`, `How to verify`, `Can skip?`), one-at-a-time/in-order execution guidance, validation expectations, change-management recommendations, and communication style.

### Testing
- Ran repository inspection commands `git status --short`, `sed -n '1,220p' AGENTS.md`, and `nl -ba AGENTS.md` and confirmed the new file was created and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a4b98dec832bbc179bbac6454a88)