### PR TITLE
Add picker-driven BOM target selection and resolver

### DIFF
--- a/Component_Picker_Workflow.md
+++ b/Component_Picker_Workflow.md
@@ -44,14 +44,16 @@ Note on Gate popups: successful Gate checks are now silent by default; failures 
 > If nothing is selected, add macros now offer: **Yes = use all displayed rows**, **No = open PN/Rev dialog (BOM flow)**, **Cancel = stop**.
 
 ### A) Add to BOM
-1. Navigate to the destination BOM sheet and ensure the BOM table is the first ListObject on that sheet.
-2. Run: `UI_Add_SelectedPickerRows_To_ActiveBOM`
-3. Enter default quantity when prompted.
-4. Choose quantity mode:
+1. Stay on `Pickers`, select one or more rows in `Pickers!TBL_PICK_RESULTS`.
+2. Choose the destination BOM in `Pickers!B9` (**Target BOM**, dropdown sourced from `BOMS.TBL_BOMS[BOMTab]`).
+3. Run: `UI_Add_SelectedPickerRows_To_ActiveBOM`
+4. Enter default quantity when prompted.
+5. Choose quantity mode:
    - **No**: apply default quantity to all selected rows
    - **Yes**: prompt for each selected row quantity
 
 Behavior:
+- Picker-driven BOM adds resolve the target BOM from `Pickers!B9`; no BOM sheet switch is required.
 - If PN+Rev already exists in BOM, `QtyPer` is incremented.
 - If PN+Rev is new, a row is inserted.
 


### PR DESCRIPTION
### Motivation
- Remove `ActiveSheet` dependency for picker-driven BOM adds so users can stay on the `Pickers` sheet when choosing a BOM target. 
- Expose an explicit BOM target input on the `Pickers` UI to make target selection discoverable and reduce context switching. 
- Prefer editable BOMs when offering target choices to prevent attempts to write into locked/obsolete BOMs.

### Description
- Added constants `CELL_BOMTARGET` and `HELPER_BOMTARGET_TOPLEFT` and shifted the results table anchor to `A11` so the new target input sits above results. 
- Updated `EnsurePickerSheetAndTable` to add the label `"Target BOM (dropdown from BOMS)"`, initialize `Pickers!B9`, and to set a default from helpers after rebuilding dropdowns. 
- Implemented `BuildBomTargetOptions(wb, dicBomTabs)` to populate a BOM dropdown from `BOMS.TBL_BOMS[BOMTab]`, preferring editable BOMs via `M_Data_BOMs_Status.CanEditBom` with fallback to all BOM tabs, and wired validation for `Pickers!B9`. 
- Added `ResolveBomTableFromPickerSelection(wb, bomTab)` that resolves the BOM worksheet + first `ListObject` and validates required BOM columns, and updated `ResolveTargetTable` to call this for `PickerTarget_BOM`. 
- Preserved legacy/manual flows by keeping `GetActiveBomTable` and routing the explicit `AddComponentByPNRev`/manual path to use it. 
- Updated `Component_Picker_Workflow.md` to document: select rows on `Pickers`, choose target BOM in `Pickers!B9`, then run the add macro without switching sheets.

### Testing
- Ran a symbol/file search with `rg -n "CELL_BOMTARGET|HELPER_BOMTARGET_TOPLEFT|ResolveBomTableFromPickerSelection|BuildBomTargetOptions" M_Data_BOMs_Picker.bas Component_Picker_Workflow.md` to confirm new symbols and doc updates were present (succeeded). 
- Performed a diff check using `git diff --check` which reported only a line-ending normalization warning and no functional diff errors (succeeded with a normalization warning). 
- Reviewed the file diffs to ensure the picker layout, dropdown population, resolver, and documentation changes were applied (inspection completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998afa5d0c4832ba2f7d422fa2c01c4)