### PR TITLE
Add M_Core_UX helper and suppress success MsgBox across operational flows

### DIFF
--- a/M_Core_UX.bas
+++ b/M_Core_UX.bas
@@ -1,0 +1,122 @@
+Attribute VB_Name = "M_Core_UX"
+Option Explicit
+
+'===============================================================================
+' Module: M_Core_UX
+'
+' Purpose:
+'   Central UX policy helpers for operational macros.
+'   - Success confirmations are suppressed by default.
+'   - Success confirmations can be enabled from Landing[DEV MODE?].
+'   - Failure messaging remains explicit and points users to Log.
+'
+' Version: v0.1.0
+'===============================================================================
+
+Public Function ShouldShowSuccessMessage(ByVal actionName As String) As Boolean
+    Dim wb As Workbook
+
+    On Error GoTo Fallback
+
+    Set wb = ThisWorkbook
+    ShouldShowSuccessMessage = LandingFlagValue(wb, "DEV MODE?", False)
+    Exit Function
+
+Fallback:
+    ShouldShowSuccessMessage = False
+End Function
+
+Public Sub ShowFailureMessageWithLogFocus( _
+    ByVal procName As String, _
+    ByVal uiTitle As String, _
+    ByVal userMessage As String, _
+    Optional ByVal details As String = "", _
+    Optional ByVal errNum As Long = 0, _
+    Optional ByVal activityId As String = "")
+
+    Dim msg As String
+
+    On Error Resume Next
+
+    M_Core_Logging.LogEvent procName, LOG_LEVEL_ERROR, userMessage, details, errNum, activityId
+
+    msg = userMessage
+    If errNum <> 0 Then
+        msg = msg & vbCrLf & "Error " & CStr(errNum) & ": " & ErrDescriptionOrFallback(details)
+    End If
+    msg = msg & vbCrLf & "See Log sheet for details."
+
+    MsgBox msg, vbExclamation, uiTitle
+End Sub
+
+Private Function ErrDescriptionOrFallback(ByVal details As String) As String
+    If Len(Trim$(details)) > 0 Then
+        ErrDescriptionOrFallback = details
+    Else
+        ErrDescriptionOrFallback = "Unexpected error"
+    End If
+End Function
+
+Private Function LandingFlagValue(ByVal wb As Workbook, ByVal headerName As String, ByVal defaultValue As Boolean) As Boolean
+    Dim ws As Worksheet
+    Dim lo As ListObject
+    Dim idx As Long
+    Dim headerCell As Range
+
+    On Error GoTo Fallback
+
+    Set ws = wb.Worksheets(SH_LANDING)
+
+    For Each lo In ws.ListObjects
+        idx = GetListColumnIndex(lo, headerName)
+        If idx > 0 Then
+            If Not lo.DataBodyRange Is Nothing Then
+                LandingFlagValue = ParseBoolean(lo.ListColumns(idx).DataBodyRange.Cells(1, 1).Value, defaultValue)
+                Exit Function
+            End If
+        End If
+    Next lo
+
+Fallback:
+    On Error Resume Next
+    Set headerCell = ws.Rows(1).Find(What:=headerName, LookIn:=xlValues, LookAt:=xlWhole, MatchCase:=False)
+    On Error GoTo 0
+
+    If Not headerCell Is Nothing Then
+        LandingFlagValue = ParseBoolean(ws.Cells(2, headerCell.Column).Value, defaultValue)
+    Else
+        LandingFlagValue = defaultValue
+    End If
+End Function
+
+Private Function GetListColumnIndex(ByVal lo As ListObject, ByVal headerName As String) As Long
+    Dim lc As ListColumn
+
+    For Each lc In lo.ListColumns
+        If StrComp(lc.Name, headerName, vbTextCompare) = 0 Then
+            GetListColumnIndex = lc.Index
+            Exit Function
+        End If
+    Next lc
+
+    GetListColumnIndex = 0
+End Function
+
+Private Function ParseBoolean(ByVal v As Variant, ByVal defaultValue As Boolean) As Boolean
+    Dim s As String
+
+    If IsError(v) Or IsNull(v) Then
+        ParseBoolean = defaultValue
+        Exit Function
+    End If
+
+    s = UCase$(Trim$(CStr(v)))
+    Select Case s
+        Case "TRUE", "YES", "Y", "1", "ON"
+            ParseBoolean = True
+        Case "FALSE", "NO", "N", "0", "OFF"
+            ParseBoolean = False
+        Case Else
+            ParseBoolean = defaultValue
+    End Select
+End Function

--- a/M_DATA_WOS_Add.bas
+++ b/M_DATA_WOS_Add.bas
@@ -78,8 +78,7 @@ Public Sub UI_Add_WOS_Build()
 
 EH:
     M_Core_Logging.LogError PROC_NAME, "UI add build failed", Err.Description, Err.Number
-    MsgBox "New build failed." & vbCrLf & _
-           "Error " & Err.Number & ": " & Err.Description, vbExclamation, "New Build"
+    M_Core_UX.ShowFailureMessageWithLogFocus PROC_NAME, "New Build", "New build failed.", Err.Description, Err.Number
 End Sub
 
 Public Sub Add_WOS_Build_FromInputs(ByVal assemblyId As String, ByVal dueDate As Date, ByVal buildQty As Long, ByVal destination As String, _
@@ -150,14 +149,15 @@ Public Sub Add_WOS_Build_FromInputs(ByVal assemblyId As String, ByVal dueDate As
     M_Core_Logging.LogInfo PROC_NAME, "Created WOS build", _
         "BuildID=" & buildId & "; AssemblyID=" & assemblyId & "; Qty=" & CStr(buildQty) & "; DueCol=" & dueDateCol & "; Version=" & MODULE_VERSION
 
-    MsgBox "Build created successfully." & vbCrLf & _
-           "BuildID: " & buildId, vbInformation, "New Build"
+    If M_Core_UX.ShouldShowSuccessMessage("Add_WOS_Build_FromInputs") Then
+        MsgBox "Build created successfully." & vbCrLf & _
+               "BuildID: " & buildId, vbInformation, "New Build"
+    End If
     Exit Sub
 
 EH:
     M_Core_Logging.LogError PROC_NAME, "Create WOS build failed", Err.Description, Err.Number
-    MsgBox "Create build failed." & vbCrLf & _
-           "Error " & Err.Number & ": " & Err.Description, vbExclamation, "New Build"
+    M_Core_UX.ShowFailureMessageWithLogFocus PROC_NAME, "New Build", "Create build failed.", Err.Description, Err.Number
 End Sub
 
 Public Function Update_WOS_Build_Controlled(ByVal buildId As String, _

--- a/M_Data_BOMs_Entry.bas
+++ b/M_Data_BOMs_Entry.bas
@@ -65,7 +65,7 @@ Public Sub UI_Create_BOM_For_Assembly( _
         Exit Sub
     End If
 
-    Create_BOM_For_Assembly_FromInputs taId, taPn, taRev, taDesc, bomNotes
+    Create_BOM_For_Assembly_Worker taId, taPn, taRev, taDesc, bomNotes, True
     Exit Sub
 
 EH:
@@ -73,12 +73,23 @@ EH:
            "Error " & Err.Number & ": " & Err.Description, vbExclamation, PROC_NAME
 End Sub
 
+Private Sub Create_BOM_For_Assembly_Worker( _
+    ByVal taId As String, _
+    ByVal taPn As String, _
+    ByVal taRev As String, _
+    ByVal taDesc As String, _
+    Optional ByVal bomNotes As String = "", _
+    Optional ByVal showSuccessMessage As Boolean = False)
+    Create_BOM_For_Assembly_FromInputs taId, taPn, taRev, taDesc, bomNotes, showSuccessMessage
+End Sub
+
 Public Sub Create_BOM_For_Assembly_FromInputs( _
     ByVal taId As String, _
     ByVal taPn As String, _
     ByVal taRev As String, _
     ByVal taDesc As String, _
-    Optional ByVal bomNotes As String = "")
+    Optional ByVal bomNotes As String = "", _
+    Optional ByVal showSuccessMessage As Boolean = False)
     Const PROC_NAME As String = "M_Data_BOMs_Entry.Create_BOM_For_Assembly_FromInputs"
 
     Const SH_TEMPLATE As String = "BOM_TEMPLATE"
@@ -250,10 +261,12 @@ If ColumnExists(loBoms, "CreatedBy") Then SetByHeader loBoms, lr, "CreatedBy", c
 If ColumnExists(loBoms, "UpdatedAt") Then SetByHeader loBoms, lr, "UpdatedAt", createdAt
 If ColumnExists(loBoms, "UpdatedBy") Then SetByHeader loBoms, lr, "UpdatedBy", createdBy
 
-MsgBox "New BOM created: " & bomId & vbCrLf & _
-          "Sheet: " & newSheetName & vbCrLf & _
-          "TAID: " & taId & vbCrLf & _
-          "PN/Rev: " & taPn & " / " & taRev, vbInformation, "New BOM"
+If showSuccessMessage And M_Core_UX.ShouldShowSuccessMessage("UI_Create_BOM_For_Assembly") Then
+    MsgBox "New BOM created: " & bomId & vbCrLf & _
+              "Sheet: " & newSheetName & vbCrLf & _
+              "TAID: " & taId & vbCrLf & _
+              "PN/Rev: " & taPn & " / " & taRev, vbInformation, "New BOM"
+End If
 
 CleanExit:
 Exit Sub

--- a/M_Data_BOMs_Picker.bas
+++ b/M_Data_BOMs_Picker.bas
@@ -352,7 +352,9 @@ Private Sub UI_Add_SelectedPickerRows_ToContext(ByVal targetContext As PickerTar
 
     AddPickedRowsToTarget wb, loPick, rowIndices, targetContext, qtyDefault, promptPerRowQty
 
-    MsgBox "Selected components processed for " & ContextLabel(targetContext) & ".", vbInformation, "Component Picker"
+    If M_Core_UX.ShouldShowSuccessMessage("BOM_Picker_Add_Flows") Then
+        MsgBox "Selected components processed for " & ContextLabel(targetContext) & ".", vbInformation, "Component Picker"
+    End If
     Exit Sub
 
 EH:

--- a/M_Data_Calc_Demand.bas
+++ b/M_Data_Calc_Demand.bas
@@ -34,7 +34,7 @@ Public Sub UI_Recalc_Demand_From_WOS_BOM()
     On Error GoTo EH
 
     If Not M_Core_Gate.Gate_Ready(True) Then Exit Sub
-    Recalc_Demand_From_WOS_BOM True
+    Recalc_Demand_From_WOS_BOM M_Core_UX.ShouldShowSuccessMessage("UI_Recalc_Demand_From_WOS_BOM")
     Exit Sub
 
 EH:

--- a/M_Data_Comps_Entry.bas
+++ b/M_Data_Comps_Entry.bas
@@ -280,9 +280,11 @@ Private Sub RunNewComponent()
     SetByHeader loComps, lr, "IsBuildable", buildable
 
     createdOk = True
-    MsgBox "Component created: " & compId & vbCrLf & _
-           "Supplier: " & pickName & " [" & pickId & "]" & vbCrLf & _
-           "IsBuildable: " & IIf(buildable, "TRUE", "FALSE"), vbInformation, "New Component"
+    If M_Core_UX.ShouldShowSuccessMessage("RunNewComponent") Then
+        MsgBox "Component created: " & compId & vbCrLf & _
+               "Supplier: " & pickName & " [" & pickId & "]" & vbCrLf & _
+               "IsBuildable: " & IIf(buildable, "TRUE", "FALSE"), vbInformation, "New Component"
+    End If
     Exit Sub
 
 FailRollback:


### PR DESCRIPTION
### Motivation

- Reduce noisy success popups in user-triggered flows while keeping failure/cancel messages visible and actionable. 
- Allow developers to opt-in to verbose success confirmations via a Landing flag (`DEV MODE?`) for diagnostics.

### Description

- Added new core module `M_Core_UX` providing `ShouldShowSuccessMessage(actionName As String) As Boolean` (driven by Landing `DEV MODE?`) and `ShowFailureMessageWithLogFocus(...)` to standardize failure UX and log-first guidance.
- Gate success confirmations in key operational entry points so they only show when `ShouldShowSuccessMessage(...)` is true: `M_Data_Comps_Entry.RunNewComponent`, `M_DATA_WOS_Add.Add_WOS_Build_FromInputs`, `M_Data_Calc_Demand.UI_Recalc_Demand_From_WOS_BOM`, and `M_Data_BOMs_Picker` add flow.
- Refactored BOM creation flow to add a small worker wrapper `Create_BOM_For_Assembly_Worker` and to add an optional `showSuccessMessage` parameter to `Create_BOM_For_Assembly_FromInputs` so success UX can be controlled by callers and policy.
- Failure handlers in WOS creation now use `M_Core_UX.ShowFailureMessageWithLogFocus(...)` to ensure failures are logged and users are directed to the Log sheet; existing failure/cancel messaging in other modules was preserved.

### Testing

- Ran targeted static checks and code searches to verify the success popup calls were replaced or gated by `M_Core_UX.ShouldShowSuccessMessage(...)` in the modified modules and that `ShowFailureMessageWithLogFocus(...)` is used in WOS failure paths, and all expected references were updated.
- Performed a file-level sanity review of the modified modules (`M_Core_UX.bas`, `M_Data_Comps_Entry.bas`, `M_Data_BOMs_Entry.bas`, `M_DATA_WOS_Add.bas`, `M_Data_Calc_Demand.bas`, `M_Data_BOMs_Picker.bas`) to ensure no accidental removal of failure/cancel messages and that helper functions are referenced correctly.
- No unit tests exist for these VBA flows, so verification was limited to static edits and pattern validation, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d80b6e28832bad84be6bfb0bfbcc)