### PR TITLE
Ensure required schema fields are populated and validated; skip closed builds in demand calc; UI focus tweaks

### DIFF
--- a/M_DATA_WOS_Add.bas
+++ b/M_DATA_WOS_Add.bas
@@ -184,6 +184,13 @@ Public Sub SYS_AddWOSBuildFromInputs(ByVal assemblyId As String, ByVal dueDate A
     If ColumnExists(loWos, "BuildStatus") Then SetByHeader loWos, lr, "BuildStatus", BUILD_STATUS_PLANNED
     If ColumnExists(loWos, "BuildNotes") Then SetByHeader loWos, lr, "BuildNotes", buildNotes
 
+    Dim missingRequired As String
+    missingRequired = EnsureRequiredFieldsFilled(loWos, lr, SH_WOS, TBL_WOS)
+    If Len(missingRequired) > 0 Then
+        If Not lr Is Nothing Then lr.Delete
+        Err.Raise vbObjectError + 7007, PROC_NAME, "Missing required field(s) after defaults: " & missingRequired
+    End If
+
     nowStamp = Now
     actor = SafeActorName()
     StampAuditIfPresent loWos, lr, actor, nowStamp
@@ -438,6 +445,87 @@ Private Function GetSchemaDefaultValue(ByVal tabName As String, ByVal tableName 
             Exit Function
         End If
     Next r
+End Function
+
+Private Function EnsureRequiredFieldsFilled(ByVal lo As ListObject, ByVal lr As ListRow, ByVal tabName As String, ByVal tableName As String) As String
+    Const SCHEMA_TABLE As String = "TBL_SCHEMA"
+    Const H_TAB As String = "TAB_NAME"
+    Const H_TBL As String = "TABLE_NAME"
+    Const H_COL As String = "COLUMN_HEADER"
+    Const H_REQ As String = "IsRequired"
+    Const H_DEF As String = "DefaultValue"
+
+    Dim wb As Workbook
+    Dim ws As Worksheet
+    Dim loSchema As ListObject
+    Dim idxTab As Long, idxTbl As Long, idxCol As Long, idxReq As Long, idxDef As Long
+    Dim arr As Variant
+    Dim r As Long
+    Dim missingList As String
+
+    Set wb = ThisWorkbook
+
+    For Each ws In wb.Worksheets
+        On Error Resume Next
+        Set loSchema = ws.ListObjects(SCHEMA_TABLE)
+        On Error GoTo 0
+        If Not loSchema Is Nothing Then Exit For
+    Next ws
+    If loSchema Is Nothing Then Exit Function
+    If loSchema.DataBodyRange Is Nothing Then Exit Function
+
+    idxTab = GetColIndex(loSchema, H_TAB)
+    idxTbl = GetColIndex(loSchema, H_TBL)
+    idxCol = GetColIndex(loSchema, H_COL)
+    idxReq = GetColIndex(loSchema, H_REQ)
+    idxDef = GetColIndex(loSchema, H_DEF)
+    If idxTab = 0 Or idxTbl = 0 Or idxCol = 0 Or idxReq = 0 Then Exit Function
+
+    arr = loSchema.DataBodyRange.Value
+    For r = 1 To UBound(arr, 1)
+        Dim schemaTab As String, schemaTbl As String, colH As String
+        schemaTab = Trim$(CStr(arr(r, idxTab)))
+        schemaTbl = Trim$(CStr(arr(r, idxTbl)))
+        colH = Trim$(CStr(arr(r, idxCol)))
+
+        If StrComp(schemaTab, tabName, vbTextCompare) = 0 _
+           And StrComp(schemaTbl, tableName, vbTextCompare) = 0 _
+           And Len(colH) > 0 Then
+
+            If IsTrueish(arr(r, idxReq)) And ColumnExists(lo, colH) Then
+                If CellIsBlankish(lr.Range.Cells(1, GetColIndex(lo, colH)).Value) Then
+                    Dim defVal As String
+                    If idxDef > 0 Then defVal = Trim$(CStr(arr(r, idxDef)))
+                    If Len(defVal) > 0 Then
+                        SetByHeader lo, lr, colH, defVal
+                    End If
+                End If
+
+                If CellIsBlankish(lr.Range.Cells(1, GetColIndex(lo, colH)).Value) Then
+                    If Len(missingList) > 0 Then missingList = missingList & ", "
+                    missingList = missingList & colH
+                End If
+            End If
+        End If
+    Next r
+
+    EnsureRequiredFieldsFilled = missingList
+End Function
+
+Private Function IsTrueish(ByVal v As Variant) As Boolean
+    Dim s As String
+    s = UCase$(Trim$(CStr(v)))
+    IsTrueish = (s = "Y" Or s = "YES" Or s = "TRUE" Or s = "1")
+End Function
+
+Private Function CellIsBlankish(ByVal v As Variant) As Boolean
+    If IsError(v) Then
+        CellIsBlankish = True
+    ElseIf IsNull(v) Or IsEmpty(v) Then
+        CellIsBlankish = True
+    Else
+        CellIsBlankish = (Len(Trim$(CStr(v))) = 0)
+    End If
 End Function
 
 Private Sub StampAuditIfPresent(ByVal lo As ListObject, ByVal lr As ListRow, ByVal actor As String, ByVal ts As Date)

--- a/M_Data_BOMs_Entry.bas
+++ b/M_Data_BOMs_Entry.bas
@@ -260,6 +260,7 @@ wsNew.Range("C1").Value = taId
 wsNew.Range("C2").Value = taPn
 wsNew.Range("C3").Value = taRev
 wsNew.Range("C4").Value = taDesc
+wsNew.Range("C5").Value = bomId
 
     ' Register in BOMS table
 Dim lr As ListRow

--- a/M_Data_Calc_Demand.bas
+++ b/M_Data_Calc_Demand.bas
@@ -122,27 +122,32 @@ Private Sub BuildBomLookup(ByVal loBoms As ListObject, ByVal dictBomTabByTaid As
 End Sub
 
 Private Sub AccumulateDemand(ByVal loWos As ListObject, ByVal dictBomTabByTaid As Object, ByVal dictDemand As Object)
-    Dim idxAssembly As Long, idxBuildQty As Long
-    Dim arrAssembly As Variant, arrBuildQty As Variant
+    Dim idxAssembly As Long, idxBuildQty As Long, idxBuildStatus As Long
+    Dim arrAssembly As Variant, arrBuildQty As Variant, arrBuildStatus As Variant
     Dim i As Long
 
     Dim assemblyId As String
     Dim buildQty As Double
     Dim bomTab As String
+    Dim buildStatus As String
 
     idxAssembly = GetColIndex(loWos, "AssemblyID")
     idxBuildQty = GetColIndex(loWos, "BuildQuantity")
+    idxBuildStatus = GetColIndex(loWos, "BuildStatus")
 
     If loWos.DataBodyRange Is Nothing Then Exit Sub
 
     arrAssembly = To2DColumnMatrix(loWos.ListColumns(idxAssembly).DataBodyRange)
     arrBuildQty = To2DColumnMatrix(loWos.ListColumns(idxBuildQty).DataBodyRange)
+    If idxBuildStatus > 0 Then arrBuildStatus = To2DColumnMatrix(loWos.ListColumns(idxBuildStatus).DataBodyRange)
 
     For i = 1 To UBound(arrAssembly, 1)
         assemblyId = Trim$(CStr(arrAssembly(i, 1)))
         buildQty = ParsePositiveDouble(arrBuildQty(i, 1))
+        buildStatus = UCase$(ReadArrText(arrBuildStatus, i))
 
         If Len(assemblyId) = 0 Or buildQty <= 0 Then GoTo ContinueLoop
+        If Not IsOpenBuildStatus(buildStatus) Then GoTo ContinueLoop
         If Not dictBomTabByTaid.Exists(assemblyId) Then GoTo ContinueLoop
 
         bomTab = CStr(dictBomTabByTaid(assemblyId))
@@ -310,6 +315,23 @@ Private Function ReadArrText(ByVal arr As Variant, ByVal idx As Long) As String
 EH:
     ReadArrText = vbNullString
 End Function
+
+Private Function IsOpenBuildStatus(ByVal buildStatus As String) As Boolean
+    buildStatus = UCase$(Trim$(buildStatus))
+
+    If Len(buildStatus) = 0 Then
+        IsOpenBuildStatus = True
+        Exit Function
+    End If
+
+    Select Case buildStatus
+        Case "SHIPPED", "CLOSED", "COMPLETE", "COMPLETED", "CANCELLED", "CANCELED"
+            IsOpenBuildStatus = False
+        Case Else
+            IsOpenBuildStatus = True
+    End Select
+End Function
+
 
 Private Sub ClearTableRows(ByVal lo As ListObject)
     Dim i As Long

--- a/M_Data_Comps_Entry.bas
+++ b/M_Data_Comps_Entry.bas
@@ -289,6 +289,13 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
 
     SetByHeader loComps, lr, "IsBuildable", buildable
 
+    Dim missingRequired As String
+    missingRequired = EnsureRequiredFieldsFilled(loComps, lr, "Comps", "TBL_COMPS")
+    If Len(missingRequired) > 0 Then
+        abortedReason = "Missing required field(s) after defaults: " & missingRequired
+        GoTo FailRollback
+    End If
+
     If Not M_Core_DataIntegrity.RunDataCheck(False) Then
         abortedReason = "Schema/data integrity requirements failed after component entry. " & DataCheckSummary()
         M_Core_Logging.LogWarn PROC_NAME, "Data integrity failed after component entry", _
@@ -325,13 +332,101 @@ Aborted:
     Exit Function
 
 EH:
+    Dim errNum As Long
+    Dim errDesc As String
+
+    errNum = Err.Number
+    errDesc = Err.Description
+
     On Error Resume Next
     If Not lr Is Nothing Then lr.Delete
     On Error GoTo 0
-    failureReason = "Error " & CStr(Err.Number) & ": " & Err.Description
+
+    failureReason = "Error " & CStr(errNum) & ": " & errDesc
     GoToLogSheet
     MsgBox "No new component created." & vbCrLf & _
-           "Error " & Err.Number & ": " & Err.Description, vbOKOnly, "New Component"
+           "Error " & errNum & ": " & errDesc, vbOKOnly, "New Component"
+End Function
+
+Private Function EnsureRequiredFieldsFilled(ByVal lo As ListObject, ByVal lr As ListRow, ByVal tabName As String, ByVal tableName As String) As String
+    Const SCHEMA_TABLE As String = "TBL_SCHEMA"
+    Const H_TAB As String = "TAB_NAME"
+    Const H_TBL As String = "TABLE_NAME"
+    Const H_COL As String = "COLUMN_HEADER"
+    Const H_REQ As String = "IsRequired"
+    Const H_DEF As String = "DefaultValue"
+
+    Dim wb As Workbook
+    Dim ws As Worksheet
+    Dim loSchema As ListObject
+    Dim idxTab As Long, idxTbl As Long, idxCol As Long, idxReq As Long, idxDef As Long
+    Dim arr As Variant
+    Dim r As Long
+    Dim missingList As String
+
+    Set wb = ThisWorkbook
+
+    For Each ws In wb.Worksheets
+        On Error Resume Next
+        Set loSchema = ws.ListObjects(SCHEMA_TABLE)
+        On Error GoTo 0
+        If Not loSchema Is Nothing Then Exit For
+    Next ws
+    If loSchema Is Nothing Then Exit Function
+    If loSchema.DataBodyRange Is Nothing Then Exit Function
+
+    idxTab = GetColIndex(loSchema, H_TAB)
+    idxTbl = GetColIndex(loSchema, H_TBL)
+    idxCol = GetColIndex(loSchema, H_COL)
+    idxReq = GetColIndex(loSchema, H_REQ)
+    idxDef = GetColIndex(loSchema, H_DEF)
+    If idxTab = 0 Or idxTbl = 0 Or idxCol = 0 Or idxReq = 0 Then Exit Function
+
+    arr = loSchema.DataBodyRange.Value
+    For r = 1 To UBound(arr, 1)
+        Dim schemaTab As String, schemaTbl As String, colH As String
+        schemaTab = Trim$(CStr(arr(r, idxTab)))
+        schemaTbl = Trim$(CStr(arr(r, idxTbl)))
+        colH = Trim$(CStr(arr(r, idxCol)))
+
+        If StrComp(schemaTab, tabName, vbTextCompare) = 0 _
+           And StrComp(schemaTbl, tableName, vbTextCompare) = 0 _
+           And Len(colH) > 0 Then
+
+            If IsTrueish(arr(r, idxReq)) And ColumnExists(lo, colH) Then
+                If CellIsBlankish(lr.Range.Cells(1, GetColIndex(lo, colH)).Value) Then
+                    Dim defVal As String
+                    If idxDef > 0 Then defVal = Trim$(CStr(arr(r, idxDef)))
+                    If Len(defVal) > 0 Then
+                        SetByHeader lo, lr, colH, defVal
+                    End If
+                End If
+
+                If CellIsBlankish(lr.Range.Cells(1, GetColIndex(lo, colH)).Value) Then
+                    If Len(missingList) > 0 Then missingList = missingList & ", "
+                    missingList = missingList & colH
+                End If
+            End If
+        End If
+    Next r
+
+    EnsureRequiredFieldsFilled = missingList
+End Function
+
+Private Function IsTrueish(ByVal v As Variant) As Boolean
+    Dim s As String
+    s = UCase$(Trim$(CStr(v)))
+    IsTrueish = (s = "Y" Or s = "YES" Or s = "TRUE" Or s = "1")
+End Function
+
+Private Function CellIsBlankish(ByVal v As Variant) As Boolean
+    If IsError(v) Then
+        CellIsBlankish = True
+    ElseIf IsNull(v) Or IsEmpty(v) Then
+        CellIsBlankish = True
+    Else
+        CellIsBlankish = (Len(Trim$(CStr(v))) = 0)
+    End If
 End Function
 
 '==========================

--- a/M_UI_Comps.bas
+++ b/M_UI_Comps.bas
@@ -42,6 +42,7 @@ Public Sub UI_OP_NewComponent()
     createdOk = M_Data_Comps_Entry.NewComponent_Create(attemptedCompId, failureReason)
 
     If createdOk Then
+        FocusCompsAndSortNewest
         M_Core_Logging.LogInfo PROC_NAME, "End: New Component", _
             "Result=SUCCESS; CompID=" & attemptedCompId & "; ModuleVersion=" & MODULE_VERSION
     Else

--- a/M_UI_Suppliers.bas
+++ b/M_UI_Suppliers.bas
@@ -38,6 +38,7 @@ Public Sub UI_OP_NewSupplier()
     M_Core_Logging.LogInfo PROC_NAME, "Start: New Supplier"
 
     M_Data_Suppliers_Entry.SYS_NewSupplier
+    FocusSuppliersAndSortNewest
 
     M_Core_Logging.LogInfo PROC_NAME, "Success: New Supplier"
 


### PR DESCRIPTION
### Motivation
- Ensure new rows have required columns populated by schema defaults and fail early if required fields remain blank after defaults are applied. 
- Prevent closed/shipped builds from contributing to demand calculations. 
- Improve UX by refocusing and sorting relevant sheets after creating new components or suppliers and make error messages more robust.

### Description
- Added `EnsureRequiredFieldsFilled`, `IsTrueish`, and `CellIsBlankish` helper functions (duplicated where needed) to read `TBL_SCHEMA` and apply defaults or report missing required columns when adding new rows. 
- Integrated `EnsureRequiredFieldsFilled` into WOS build creation (`M_DATA_WOS_Add`) and component creation (`M_Data_Comps_Entry`) to rollback/raise errors or abort when required fields remain blank. 
- Added `IsOpenBuildStatus` and updated `M_Data_Calc_Demand.AccumulateDemand` to ignore builds with closed/shipped statuses when accumulating demand. 
- Set `C5` on new BOM sheets to `bomId` and kept BOM registration logic in `M_Data_BOMs_Entry`. 
- Improved error reporting in `RunNewComponent` by capturing `Err.Number`/`Err.Description` into local variables before cleanup to avoid stale Err after rollback. 
- Added small UX fixes to refocus and sort sheets after creating a component (`M_UI_Comps`) or supplier (`M_UI_Suppliers`).

### Testing
- Compiled the VBA project and resolved compile-time issues; compilation completed with no errors. 
- No automated unit test suite was available to run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f8156b424832bb117a4cdef9e7359)