### PR TITLE
Improve named-range handling and diagnostics; add developer audit tool

### DIFF
--- a/Dev_NamedRange_Diagnostics.bas
+++ b/Dev_NamedRange_Diagnostics.bas
@@ -1,0 +1,229 @@
+Attribute VB_Name = "Dev_NamedRange_Diagnostics"
+Option Explicit
+
+'===============================================================================
+' Module: Dev_NamedRange_Diagnostics
+'
+' Purpose:
+'   Developer diagnostics for named-range issues that can break list prompts
+'   (e.g., NR_RevStatus errors during new component creation).
+'
+' Entry point:
+'   DEV_AuditNamedRanges
+'
+' Output:
+'   Writes findings to sheet: DEV_NR_AUDIT
+'===============================================================================
+
+Public Sub DEV_AuditNamedRanges()
+    Const PROC_NAME As String = "Dev_NamedRange_Diagnostics.DEV_AuditNamedRanges"
+    Const OUT_SHEET As String = "DEV_NR_AUDIT"
+
+    Dim wb As Workbook
+    Dim wsOut As Worksheet
+    Dim targets As Variant
+    Dim target As Variant
+    Dim rowOut As Long
+
+    On Error GoTo EH
+
+    Set wb = ThisWorkbook
+    targets = Array("NR_RevStatus", "NR_UOM", "NR_IMSStatus")
+
+    Set wsOut = PrepareOutputSheet(wb, OUT_SHEET)
+    rowOut = 2
+
+    Dim i As Long
+    For i = LBound(targets) To UBound(targets)
+        target = CStr(targets(i))
+        rowOut = AuditOneNamedRange(wb, wsOut, rowOut, CStr(target))
+    Next i
+
+    wsOut.Columns("A:N").EntireColumn.AutoFit
+    wsOut.Activate
+
+    MsgBox "Named-range audit complete." & vbCrLf & _
+           "Sheet: " & OUT_SHEET & vbCrLf & _
+           "Check rows flagged as DUPLICATE, INVALID_REF, or NO_MATCH.", vbOKOnly, "DEV_AuditNamedRanges"
+    Exit Sub
+
+EH:
+    MsgBox PROC_NAME & " failed." & vbCrLf & _
+           "Error " & Err.Number & ": " & Err.Description, vbOKOnly, "DEV_AuditNamedRanges"
+End Sub
+
+Private Function PrepareOutputSheet(ByVal wb As Workbook, ByVal sheetName As String) As Worksheet
+    Dim ws As Worksheet
+
+    On Error Resume Next
+    Set ws = wb.Worksheets(sheetName)
+    On Error GoTo 0
+
+    If ws Is Nothing Then
+        Set ws = wb.Worksheets.Add(After:=wb.Worksheets(wb.Worksheets.Count))
+        ws.Name = sheetName
+    Else
+        ws.Cells.Clear
+    End If
+
+    ws.Range("A1").Value = "TargetName"
+    ws.Range("B1").Value = "Status"
+    ws.Range("C1").Value = "ScopeType"
+    ws.Range("D1").Value = "ScopeName"
+    ws.Range("E1").Value = "NameObject"
+    ws.Range("F1").Value = "Visible"
+    ws.Range("G1").Value = "RefersTo"
+    ws.Range("H1").Value = "ResolvesToRange"
+    ws.Range("I1").Value = "RangeAddress"
+    ws.Range("J1").Value = "Rows"
+    ws.Range("K1").Value = "Cols"
+    ws.Range("L1").Value = "TopLeftValue"
+    ws.Range("M1").Value = "RefersToRangeError"
+    ws.Range("N1").Value = "Notes"
+
+    ws.Range("A1:N1").Font.Bold = True
+
+    Set PrepareOutputSheet = ws
+End Function
+
+Private Function AuditOneNamedRange(ByVal wb As Workbook, ByVal wsOut As Worksheet, ByVal rowStart As Long, ByVal targetName As String) As Long
+    Dim rowOut As Long
+    Dim matches As Long
+    Dim nm As Name
+    Dim ws As Worksheet
+
+    rowOut = rowStart
+    matches = 0
+
+    For Each nm In wb.Names
+        If NameMatches(nm.Name, targetName) Then
+            matches = matches + 1
+            WriteNameRow wsOut, rowOut, targetName, "Workbook", wb.Name, nm
+            rowOut = rowOut + 1
+        End If
+    Next nm
+
+    For Each ws In wb.Worksheets
+        For Each nm In ws.Names
+            If NameMatches(nm.Name, targetName) Then
+                matches = matches + 1
+                WriteNameRow wsOut, rowOut, targetName, "Worksheet", ws.Name, nm
+                rowOut = rowOut + 1
+            End If
+        Next nm
+    Next ws
+
+    If matches = 0 Then
+        wsOut.Cells(rowOut, 1).Value = targetName
+        wsOut.Cells(rowOut, 2).Value = "NO_MATCH"
+        wsOut.Cells(rowOut, 14).Value = "No name object found at workbook or worksheet scope."
+        rowOut = rowOut + 1
+    ElseIf matches > 1 Then
+        wsOut.Cells(rowStart, 14).Value = AppendNote(CStr(wsOut.Cells(rowStart, 14).Value), "DUPLICATE_NAME_COUNT=" & CStr(matches))
+        wsOut.Cells(rowStart, 2).Value = "DUPLICATE"
+    End If
+
+    AuditOneNamedRange = rowOut
+End Function
+
+Private Sub WriteNameRow(ByVal wsOut As Worksheet, ByVal rowOut As Long, ByVal targetName As String, ByVal scopeType As String, ByVal scopeName As String, ByVal nm As Name)
+    Dim rng As Range
+    Dim resolveOk As Boolean
+    Dim errNum As Long
+    Dim errDesc As String
+
+    wsOut.Cells(rowOut, 1).Value = targetName
+    wsOut.Cells(rowOut, 2).Value = "OK"
+    wsOut.Cells(rowOut, 3).Value = scopeType
+    wsOut.Cells(rowOut, 4).Value = scopeName
+    wsOut.Cells(rowOut, 5).Value = nm.Name
+    wsOut.Cells(rowOut, 6).Value = CStr(nm.Visible)
+    wsOut.Cells(rowOut, 7).Value = SafeNameRefersTo(nm)
+
+    resolveOk = TryGetRangeFromName(nm, rng, errNum, errDesc)
+    wsOut.Cells(rowOut, 8).Value = IIf(resolveOk, "TRUE", "FALSE")
+
+    If resolveOk Then
+        wsOut.Cells(rowOut, 9).Value = rng.Address(External:=True)
+        wsOut.Cells(rowOut, 10).Value = rng.Rows.Count
+        wsOut.Cells(rowOut, 11).Value = rng.Columns.Count
+        wsOut.Cells(rowOut, 12).Value = SafeTopLeftValue(rng)
+    Else
+        wsOut.Cells(rowOut, 2).Value = "INVALID_REF"
+        wsOut.Cells(rowOut, 13).Value = "Err " & CStr(errNum) & ": " & errDesc
+    End If
+
+    If IsSuspiciousRefersTo(CStr(wsOut.Cells(rowOut, 7).Value)) Then
+        wsOut.Cells(rowOut, 14).Value = AppendNote(CStr(wsOut.Cells(rowOut, 14).Value), "SUSPICIOUS_REFERS_TO")
+    End If
+End Sub
+
+Private Function TryGetRangeFromName(ByVal nm As Name, ByRef rng As Range, ByRef errNum As Long, ByRef errDesc As String) As Boolean
+    On Error Resume Next
+    Set rng = nm.RefersToRange
+    errNum = Err.Number
+    errDesc = Err.Description
+    TryGetRangeFromName = (errNum = 0 And Not rng Is Nothing)
+    On Error GoTo 0
+End Function
+
+Private Function NameMatches(ByVal qualifiedName As String, ByVal targetName As String) As Boolean
+    Dim bangPos As Long
+    Dim baseName As String
+
+    baseName = Trim$(qualifiedName)
+    bangPos = InStrRev(baseName, "!")
+    If bangPos > 0 Then baseName = Mid$(baseName, bangPos + 1)
+
+    If Left$(baseName, 1) = "=" Then baseName = Mid$(baseName, 2)
+    If Left$(baseName, 1) = "'" And Right$(baseName, 1) = "'" And Len(baseName) >= 2 Then
+        baseName = Mid$(baseName, 2, Len(baseName) - 2)
+    End If
+
+    NameMatches = (StrComp(baseName, targetName, vbTextCompare) = 0)
+End Function
+
+Private Function IsSuspiciousRefersTo(ByVal refersToText As String) As Boolean
+    Dim t As String
+    t = UCase$(Trim$(refersToText))
+
+    If InStr(1, t, "#REF!", vbTextCompare) > 0 Then
+        IsSuspiciousRefersTo = True
+        Exit Function
+    End If
+
+    If InStr(1, t, ".XLS", vbTextCompare) > 0 Then
+        IsSuspiciousRefersTo = True
+        Exit Function
+    End If
+
+    IsSuspiciousRefersTo = False
+End Function
+
+Private Function SafeNameRefersTo(ByVal nm As Name) As String
+    On Error GoTo EH
+    SafeNameRefersTo = nm.RefersTo
+    Exit Function
+EH:
+    SafeNameRefersTo = "<error " & Err.Number & ": " & Err.Description & ">"
+End Function
+
+Private Function SafeTopLeftValue(ByVal rng As Range) As String
+    On Error GoTo EH
+    If rng Is Nothing Then
+        SafeTopLeftValue = vbNullString
+    Else
+        SafeTopLeftValue = CStr(rng.Cells(1, 1).Value)
+    End If
+    Exit Function
+EH:
+    SafeTopLeftValue = "<error " & Err.Number & ": " & Err.Description & ">"
+End Function
+
+Private Function AppendNote(ByVal currentNote As String, ByVal newNote As String) As String
+    If Len(Trim$(currentNote)) = 0 Then
+        AppendNote = newNote
+    Else
+        AppendNote = currentNote & "; " & newNote
+    End If
+End Function

--- a/M_Data_Comps_Entry.bas
+++ b/M_Data_Comps_Entry.bas
@@ -104,9 +104,11 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
 
     Dim createdOk As Boolean
     Dim abortedReason As String
+    Dim currentStep As String
 
     createdOk = False
     abortedReason = vbNullString
+    currentStep = "Initialization"
     attemptedCompId = vbNullString
     failureReason = vbNullString
     RunNewComponent = False
@@ -116,6 +118,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     '-----------------------------
     ' Gate check (consistency)
     '-----------------------------
+    currentStep = "Gate check"
     If Not GateReady_Safe(False) Then
         abortedReason = "Gate not ready."
         GoTo Aborted
@@ -161,6 +164,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     If Len(imsDefault) = 0 Then imsDefault = DEFAULT_IMSSTATUS_FALLBACK
 
     ' Generate CompID
+    currentStep = "Generating CompID"
     compId = GenerateNextId(loComps, "CompID", COMP_ID_PREFIX, COMP_ID_PAD)
     If Len(compId) = 0 Then Err.Raise vbObjectError + 5100, PROC_NAME, "Failed to generate CompID."
     attemptedCompId = compId
@@ -180,12 +184,14 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     SetByHeader loComps, lr, "UpdatedBy", createdBy
 
     ' Required: OurPN / OurRev
+    currentStep = "Collecting OurPN"
     ourPN = Trim$(InputBox("Enter OurPN (required).", "New Component (" & compId & ")"))
     If Len(ourPN) = 0 Then
         abortedReason = "OurPN not provided."
         GoTo FailRollback
     End If
 
+    currentStep = "Collecting OurRev"
     ourRev = Trim$(InputBox("Enter OurRev (required).", "New Component (" & compId & ")"))
     If Len(ourRev) = 0 Then
         abortedReason = "OurRev not provided."
@@ -205,6 +211,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     SetByHeader loComps, lr, "OurRev", ourRev
 
     ' Required: ComponentDescription
+    currentStep = "Collecting ComponentDescription"
     desc = Prompt_RequiredText("Enter ComponentDescription (required).", "New Component (" & compId & ")", DEFAULT_DESC)
     If Len(desc) = 0 Then
         abortedReason = "ComponentDescription not provided."
@@ -213,6 +220,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     SetByHeader loComps, lr, "ComponentDescription", desc
 
     ' Supplier selection (forced)
+    currentStep = "Selecting Supplier"
     If Not SupplierPick_ByName(loSupp, pickId, pickName, pickDfltLT) Then
         abortedReason = "Supplier selection cancelled."
         GoTo FailRollback
@@ -226,6 +234,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     End If
 
     ' Required list fields
+    currentStep = "Selecting UOM"
     uom = Prompt_ListValue("NR_UOM", "Select UOM (required).", "New Component (" & compId & ")", DEFAULT_UOM)
     If Len(uom) = 0 Then
         abortedReason = "UOM not selected."
@@ -233,6 +242,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     End If
     SetByHeader loComps, lr, "UOM", uom
 
+    currentStep = "Selecting RevStatus"
     revStatus = Prompt_ListValue("NR_RevStatus", "Select RevStatus (required).", "New Component (" & compId & ")", DEFAULT_REVSTATUS)
     If Len(revStatus) = 0 Then
         abortedReason = "RevStatus not selected."
@@ -240,6 +250,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     End If
     SetByHeader loComps, lr, "RevStatus", revStatus
 
+    currentStep = "Selecting IMSStatus"
     imsStatus = Prompt_ListValue("NR_IMSStatus", "Select IMSStatus (required).", "New Component (" & compId & ")", imsDefault)
     If Len(imsStatus) = 0 Then
         abortedReason = "IMSStatus not selected."
@@ -248,6 +259,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     SetByHeader loComps, lr, "IMSStatus", imsStatus
 
     ' Required numeric fields
+    currentStep = "Entering MOQ1"
     moq1 = Prompt_Long("Enter MOQ1 (required).", "New Component (" & compId & ")", DEFAULT_MOQ1, 1, 1000000)
     If moq1 = -1 Then
         abortedReason = "MOQ1 not provided."
@@ -255,6 +267,7 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     End If
     SetByHeader loComps, lr, "MOQ1", moq1
 
+    currentStep = "Entering CostPerUOMMOQ1"
     costMOQ1 = Prompt_Double("Enter CostPerUOMMOQ1 (required).", "New Component (" & compId & ")", DEFAULT_COST_MOQ1, 0, 1000000000#)
     If costMOQ1 < 0 Then
         abortedReason = "CostPerUOMMOQ1 not provided."
@@ -290,12 +303,14 @@ Private Function RunNewComponent(ByRef attemptedCompId As String, ByRef failureR
     SetByHeader loComps, lr, "IsBuildable", buildable
 
     Dim missingRequired As String
+    currentStep = "Applying schema defaults"
     missingRequired = EnsureRequiredFieldsFilled(loComps, lr, "Comps", "TBL_COMPS")
     If Len(missingRequired) > 0 Then
         abortedReason = "Missing required field(s) after defaults: " & missingRequired
         GoTo FailRollback
     End If
 
+    currentStep = "Running data integrity check"
     If Not M_Core_DataIntegrity.RunDataCheck(False) Then
         abortedReason = "Schema/data integrity requirements failed after component entry. " & DataCheckSummary()
         M_Core_Logging.LogWarn PROC_NAME, "Data integrity failed after component entry", _
@@ -335,15 +350,31 @@ Aborted:
     Exit Function
 
 EH:
+    Dim errNum As Long
+    Dim errDesc As String
+    Dim logDetails As String
+
+    errNum = Err.Number
+    errDesc = Trim$(Err.Description)
+
+    If errNum = 0 Then errNum = vbObjectError + 5199
+    If Len(errDesc) = 0 Then errDesc = "Unknown runtime error (Err.Description was blank)."
+
     On Error Resume Next
     If Not lr Is Nothing Then lr.Delete
     On Error GoTo 0
-    failureReason = "Error " & CStr(Err.Number) & ": " & Err.Description
-    M_Core_Logging.LogError PROC_NAME, "Component creation failed", _
-        "CompID=" & compId & "; " & failureReason, Err.Number
+
+    failureReason = "Step=" & currentStep & "; Error " & CStr(errNum) & ": " & errDesc
+    logDetails = "CompID=" & compId & "; " & failureReason & _
+                 "; NR_UOM=" & DescribeNamedRangeState("NR_UOM") & _
+                 "; NR_RevStatus=" & DescribeNamedRangeState("NR_RevStatus") & _
+                 "; NR_IMSStatus=" & DescribeNamedRangeState("NR_IMSStatus")
+
+    M_Core_Logging.LogError PROC_NAME, "Component creation failed", logDetails, errNum
     GoToLogSheet
     MsgBox "No new component created." & vbCrLf & _
-           "Error " & Err.Number & ": " & Err.Description, vbOKOnly, "New Component"
+           "Step: " & currentStep & vbCrLf & _
+           "Error " & errNum & ": " & errDesc, vbOKOnly, "New Component"
 End Function
 
 Private Function EnsureRequiredFieldsFilled(ByVal lo As ListObject, ByVal lr As ListRow, ByVal tabName As String, ByVal tableName As String) As String
@@ -522,6 +553,7 @@ Private Function Prompt_ListValue(ByVal namedRange As String, ByVal prompt As St
     Dim arr As Variant
     Dim choices() As String
     Dim i As Long, n As Long
+    Dim choiceCount As Long
     Dim menu As String
     Dim resp As String
     Dim idx As Long
@@ -542,9 +574,24 @@ Private Function Prompt_ListValue(ByVal namedRange As String, ByVal prompt As St
     End If
 
     ReDim choices(1 To n)
+    choiceCount = 0
     For i = 1 To n
-        choices(i) = Trim$(CStr(arr(i, 1)))
+        If Not IsError(arr(i, 1)) Then
+            Dim candidate As String
+            candidate = Trim$(CStr(arr(i, 1)))
+            If Len(candidate) > 0 Then
+                choiceCount = choiceCount + 1
+                choices(choiceCount) = candidate
+            End If
+        End If
     Next i
+
+    If choiceCount = 0 Then
+        Prompt_ListValue = Prompt_FreeTextValue(prompt, title, defaultValue, namedRange)
+        Exit Function
+    End If
+
+    n = choiceCount
 
 Retry:
     menu = prompt & vbCrLf & vbCrLf
@@ -654,23 +701,21 @@ Retry:
 End Function
 
 Private Sub RequireNamedRange(ByVal namedRange As String)
-    Dim nm As Name
-    On Error GoTo EH
-    Set nm = ThisWorkbook.names(namedRange)
-    If nm Is Nothing Then Err.Raise vbObjectError + 5800, "RequireNamedRange", "Named range not found: " & namedRange
-    Exit Sub
-EH:
+    Dim rng As Range
+    Dim reason As String
+
+    If TryResolveNamedRangeRange(namedRange, rng, reason) Then Exit Sub
+
     MsgBox "RequireNamedRange failed." & vbCrLf & _
-           "Error " & Err.Number & ": " & Err.Description, vbOKOnly, "New Component"
-    Err.Raise vbObjectError + 5801, "RequireNamedRange", "Named range not found: " & namedRange
+           "Named range unavailable: " & namedRange & vbCrLf & _
+           "Details: " & reason, vbOKOnly, "New Component"
+    Err.Raise vbObjectError + 5801, "RequireNamedRange", "Named range unavailable: " & namedRange & " (" & reason & ")"
 End Sub
 
 Private Function NamedRangeExists(ByVal namedRange As String) As Boolean
-    Dim nm As Name
-    On Error Resume Next
-    Set nm = ThisWorkbook.Names(namedRange)
-    On Error GoTo 0
-    NamedRangeExists = Not nm Is Nothing
+    Dim rng As Range
+    Dim reason As String
+    NamedRangeExists = TryResolveNamedRangeRange(namedRange, rng, reason)
 End Function
 
 Private Function Prompt_FreeTextValue(ByVal prompt As String, ByVal title As String, ByVal defaultValue As String, ByVal sourceName As String) As String
@@ -685,37 +730,140 @@ Private Function Prompt_FreeTextValue(ByVal prompt As String, ByVal title As Str
     End If
 End Function
 
+Private Function DescribeNamedRangeState(ByVal namedRange As String) As String
+    Dim arr As Variant
+    Dim n As Long
+    Dim sample As String
+    Dim rng As Range
+    Dim reason As String
+
+    On Error GoTo EH
+
+    If Not TryResolveNamedRangeRange(namedRange, rng, reason) Then
+        DescribeNamedRangeState = reason
+        Exit Function
+    End If
+
+    arr = GetNamedRangeValues(namedRange)
+    n = UBound(arr, 1)
+    If n <= 0 Then
+        DescribeNamedRangeState = "exists-empty"
+        Exit Function
+    End If
+
+    sample = Trim$(CStr(arr(1, 1)))
+    If Len(sample) = 0 Then sample = "<blank>"
+    DescribeNamedRangeState = "exists-count=" & CStr(n) & "; first='" & sample & "'"
+    Exit Function
+
+EH:
+    DescribeNamedRangeState = "unavailable(" & Err.Number & ": " & Err.Description & ")"
+End Function
+
 Private Function GetNamedRangeValues(ByVal namedRange As String) As Variant
     Dim rng As Range
     Dim v As Variant
     Dim outArr() As Variant
     Dim r As Long, c As Long, n As Long
+    Dim reason As String
 
-    Set rng = ThisWorkbook.names(namedRange).RefersToRange
-    v = rng.value
+    If Not TryResolveNamedRangeRange(namedRange, rng, reason) Then
+        ReDim outArr(1 To 1, 1 To 1)
+        outArr(1, 1) = vbNullString
+        GetNamedRangeValues = outArr
+        Exit Function
+    End If
+
+    v = rng.Value
 
     If IsArray(v) Then
         ReDim outArr(1 To (UBound(v, 1) * UBound(v, 2)), 1 To 1)
         n = 0
         For r = 1 To UBound(v, 1)
             For c = 1 To UBound(v, 2)
-                If Len(Trim$(CStr(v(r, c)))) > 0 Then
-                    n = n + 1
-                    outArr(n, 1) = v(r, c)
+                If Not IsError(v(r, c)) Then
+                    If Len(Trim$(CStr(v(r, c)))) > 0 Then
+                        n = n + 1
+                        outArr(n, 1) = v(r, c)
+                    End If
                 End If
             Next c
         Next r
         If n = 0 Then
-            ReDim outArr(1 To 0, 1 To 1)
+            ReDim outArr(1 To 1, 1 To 1)
+            outArr(1, 1) = vbNullString
         ElseIf n < UBound(outArr, 1) Then
             ReDim Preserve outArr(1 To n, 1 To 1)
         End If
         GetNamedRangeValues = outArr
     Else
         ReDim outArr(1 To 1, 1 To 1)
-        outArr(1, 1) = v
+        If IsError(v) Then
+            outArr(1, 1) = vbNullString
+        Else
+            outArr(1, 1) = v
+        End If
         GetNamedRangeValues = outArr
     End If
+End Function
+
+Private Function TryResolveNamedRangeRange(ByVal namedRange As String, ByRef rng As Range, ByRef reason As String) As Boolean
+    Dim nm As Name
+    Dim ws As Worksheet
+
+    reason = "missing"
+    Set rng = Nothing
+
+    For Each nm In ThisWorkbook.Names
+        If NameMatches(nm.Name, namedRange) Then
+            If TryGetRangeFromName(nm, rng) Then
+                TryResolveNamedRangeRange = True
+                Exit Function
+            End If
+            reason = "invalid-ref(" & Err.Number & ": " & Err.Description & ")"
+            Err.Clear
+        End If
+    Next nm
+
+    For Each ws In ThisWorkbook.Worksheets
+        For Each nm In ws.Names
+            If NameMatches(nm.Name, namedRange) Then
+                If TryGetRangeFromName(nm, rng) Then
+                    TryResolveNamedRangeRange = True
+                    Exit Function
+                End If
+                reason = "invalid-ref(" & Err.Number & ": " & Err.Description & ")"
+                Err.Clear
+            End If
+        Next nm
+    Next ws
+End Function
+
+Private Function TryGetRangeFromName(ByVal nm As Name, ByRef rng As Range) As Boolean
+    On Error Resume Next
+    Set rng = nm.RefersToRange
+    If Err.Number <> 0 Then
+        TryGetRangeFromName = False
+    Else
+        TryGetRangeFromName = Not rng Is Nothing
+    End If
+    On Error GoTo 0
+End Function
+
+Private Function NameMatches(ByVal qualifiedName As String, ByVal targetName As String) As Boolean
+    Dim bangPos As Long
+    Dim baseName As String
+
+    baseName = Trim$(qualifiedName)
+    bangPos = InStrRev(baseName, "!")
+    If bangPos > 0 Then baseName = Mid$(baseName, bangPos + 1)
+
+    If Left$(baseName, 1) = "=" Then baseName = Mid$(baseName, 2)
+    If Left$(baseName, 1) = "'" And Right$(baseName, 1) = "'" And Len(baseName) >= 2 Then
+        baseName = Mid$(baseName, 2, Len(baseName) - 2)
+    End If
+
+    NameMatches = (StrComp(baseName, targetName, vbTextCompare) = 0)
 End Function
 
 Private Function GetUserNameSafe() As String


### PR DESCRIPTION
### Motivation
- Reduce runtime failures during new component creation caused by missing, invalid, or empty named ranges used for list prompts.
- Improve error visibility by recording the current step and richer named-range context when component creation fails.
- Provide a developer-facing audit to inspect named-range definitions and quickly locate issues like invalid references or duplicates.

### Description
- Added a new module `Dev_NamedRange_Diagnostics` that provides `DEV_AuditNamedRanges` to scan named ranges and write diagnostics to the `DEV_NR_AUDIT` sheet, reporting status, scope, resolved ranges, addresses, and suspicious refers-to values.
- Enhanced `M_Data_Comps_Entry` to track the current processing step in `currentStep`, improve error reporting, and include named-range state (`DescribeNamedRangeState`) in `M_Core_Logging.LogError` details when creation fails.
- Reworked named-range resolution and list-prompt logic by introducing `TryResolveNamedRangeRange`, `TryGetRangeFromName`, `NameMatches`, and making `NamedRangeExists`, `GetNamedRangeValues`, `Prompt_ListValue`, and `RequireNamedRange` robust to workbook/worksheet-scoped names, invalid references, errors, and blank or error cells.
- Hardened `GetNamedRangeValues` and `Prompt_ListValue` to ignore error cells and empty entries, and to fall back to free-text prompts when no valid choices are available.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f3b865f0832bb58b460e7685d3f2)